### PR TITLE
Add basic QUnit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 ## Dark Souls Cheat Sheet
 
 To view the cheat sheet [click here](https://smcnabb.github.io/dark-souls-cheat-sheet/).
+
+## Running Tests
+
+This project includes a small QUnit test suite. Install dependencies and run the tests with:
+
+```bash
+npm install
+npm test
+```
+
+The tests execute using Node.js with jsdom to simulate a browser environment.

--- a/js/main.js
+++ b/js/main.js
@@ -198,4 +198,9 @@
         }
     }
 
+    // Expose calculateTotals for testing
+    if (typeof window !== 'undefined') {
+        window.calculateTotals = calculateTotals;
+    }
+
 })( jQuery );

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "dark-souls-cheat-sheet",
+  "version": "1.0.0",
+  "description": "Dark Souls Cheat Sheet",
+  "devDependencies": {
+    "qunit": "^2.20.0",
+    "jsdom": "^22.1.0",
+    "jquery": "^3.7.1"
+  },
+  "scripts": {
+    "test": "qunit"
+  }
+}

--- a/tests/calculateTotals.test.js
+++ b/tests/calculateTotals.test.js
@@ -1,0 +1,47 @@
+const { JSDOM } = require('jsdom');
+const QUnit = require('qunit');
+
+// Setup DOM
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+const { window } = dom;
+global.window = window;
+global.document = window.document;
+// jQuery setup
+const $ = require('jquery')(window);
+global.$ = global.jQuery = $;
+
+// Stub jStorage used by main.js
+$.jStorage = {
+  get: (_key, def) => def,
+  set: () => {}
+};
+
+// Global variable required by main.js
+global.profilesKey = 'profiles';
+
+// Load script which attaches calculateTotals to window
+require('../js/main.js');
+
+QUnit.module('calculateTotals');
+
+QUnit.test('updates totals based on checkbox states', assert => {
+  const html = `
+    <span id="foo_overall_total"></span>
+    <span id="foo_totals_1"></span>
+    <span id="foo_nav_totals_1"></span>
+    <input type="checkbox" id="foo_1_1" checked>
+    <input type="checkbox" id="foo_1_2">
+  `;
+  document.body.innerHTML = html;
+
+  window.calculateTotals();
+  assert.strictEqual(document.getElementById('foo_totals_1').textContent, '[1/2]');
+  assert.strictEqual(document.getElementById('foo_nav_totals_1').textContent, '[1/2]');
+  assert.strictEqual(document.getElementById('foo_overall_total').textContent, '[1/2]');
+
+  document.getElementById('foo_1_2').checked = true;
+  window.calculateTotals();
+  assert.strictEqual(document.getElementById('foo_totals_1').textContent, '[DONE]');
+  assert.strictEqual(document.getElementById('foo_nav_totals_1').textContent, '[DONE]');
+  assert.strictEqual(document.getElementById('foo_overall_total').textContent, '[DONE]');
+});


### PR DESCRIPTION
## Summary
- expose `calculateTotals` on `window` for testing
- add QUnit, jquery, and jsdom dev dependencies
- create a test for `calculateTotals`
- document how to run the test suite

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: qunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ede03fb48321a75789f13702628c