### PR TITLE
Fix duplicate xmlns attribute in HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html">
+<html lang="en" xmlns="http://www.w3.org/1999/html">
 <head>
     <meta charset="utf-8">
     <title>Dark Souls Cheat Sheet</title>


### PR DESCRIPTION
## Summary
- remove duplicate `xmlns` attribute from the HTML element in `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844edc7967883219fada263991e9dd2