### PR TITLE
Improve jstorage placeholder comment

### DIFF
--- a/js/jstorage.js
+++ b/js/jstorage.js
@@ -54,7 +54,9 @@
         /* This is the object, that holds the cached values */
         _storage = {},
 
-        /* Actual browser storage (localStorage or globalStorage['domain']) */
+        /* Placeholder for the actual browser storage; initialization will
+         * assign the real storage object (localStorage or
+         * globalStorage['domain']) */
         _storage_service = {jStorage:"{}"},
 
         /* DOM element for older IE versions, holds userData behavior */


### PR DESCRIPTION
## Summary
- clarify that `_storage_service` starts as a placeholder before the real storage object is assigned

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844edd7b52c8321a8380c0418a4cb15