### PR TITLE
Simplify checkbox init and enable strict mode

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,5 @@
 (function($) {
+    "use strict";
 
     var defaultProfiles = {
         'current': 'Default Profile'
@@ -12,17 +13,7 @@
 
     jQuery(document).ready(function($) {
 
-        // TODO Find a better way to do this in one pass
-        $('ul li li').each(function(index) {
-            if ($(this).attr('data-id')) {
-                addCheckbox(this);
-            }
-        });
-        $('ul li').each(function(index) {
-            if ($(this).attr('data-id')) {
-                addCheckbox(this);
-            }
-        });
+        $('li[data-id]').each(function () { addCheckbox(this); });
 
         populateProfiles();
 


### PR DESCRIPTION
## Summary
- use strict mode in `main.js`
- condense checkbox initialization to one loop

## Testing
- `npm test` *(fails: `qunit` not found)*
- `npm install` *(fails: unable to access registry)*

------
https://chatgpt.com/codex/tasks/task_e_68451ddf64988321b6b90be84135aca5