### PR TITLE
Fix CDN URLs for HTML5shiv and jQuery

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,9 +10,9 @@
     <link href="css/bootstrap-responsive.min.css" rel="stylesheet">
     <link href="css/main.css" rel="stylesheet">
     <!--[if lt IE 9]>
-        <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
-    <script src="https://code.jquery.com/jquery-latest.js"></script>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="js/jstorage.js"></script>
     <script type="text/javascript">
         var profilesKey = 'profiles';


### PR DESCRIPTION
## Summary
- use HTTPS link to html5shiv CDN
- pin jQuery version to 3.7.1

## Testing
- `npm test` *(fails: qunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68451de6e1a08321a134333aa8c3ba06