### PR TITLE
Change site name to Dark Souls Minimal Cheat Sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Dark Souls Cheat Sheet
+# Dark Souls Minimal Cheat Sheet
 
-This repository contains the code for the **Dark Souls Cheat Sheet**. The site provides a step‑by‑step checklist for the original game and saves your progress locally so you can pick up where you left off.
+This repository contains the code for the **Dark Souls Minimal Cheat Sheet**. The site provides a step‑by‑step checklist for the original game and saves your progress locally so you can pick up where you left off.
 
 [View the live site here.](https://vesylum.github.io/dark-souls-cheat-sheet/)
 

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en" xmlns="http://www.w3.org/1999/html">
 <head>
     <meta charset="utf-8">
-    <title>Dark Souls Cheat Sheet</title>
+    <title>Dark Souls Minimal Cheat Sheet</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Cheat sheet for Dark Souls. Checklist of things to do, items to get etc.">
     <meta name="author" content="Stephen McNabb">
@@ -33,7 +33,7 @@
 
         <div class="navbar">
             <div class="navbar-inner">
-                <h1>Dark Souls Cheat Sheet</h1>
+                <h1>Dark Souls Minimal Cheat Sheet</h1>
                 <ul class="nav nav-tabs">
                     <li class="active"><a href="#tabPlaythrough" data-toggle="tab">Playthrough</a></li>
                     <li><a href="#tabChecklists" data-toggle="tab">Checklists</a></li>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dark-souls-cheat-sheet",
   "version": "1.0.0",
-  "description": "Dark Souls Cheat Sheet",
+  "description": "Dark Souls Minimal Cheat Sheet",
   "devDependencies": {
     "qunit": "^2.20.0",
     "jsdom": "^22.1.0",


### PR DESCRIPTION
## Summary
- rename the site to **Dark Souls Minimal Cheat Sheet** in README, index.html, and package.json

## Testing
- `npm test` *(fails: qunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845205138cc83219e408bf9e35cf1dc