### PR TITLE
Remove DS2 cheat sheet alert

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,9 +51,6 @@
             </div>
         </div>
 
-        <div class="alert alert-info">
-            <strong>Heads Up!</strong> The <a class="alert-link" href="https://smcnabb.github.io/dark-souls-2-cheat-sheet/">Dark Souls 2 Cheat Sheet</a> is now available.
-        </div>
 
         <div id="intro">
 


### PR DESCRIPTION
## Summary
- remove outdated notice about the Dark Souls 2 cheat sheet

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: qunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684528f67fa08321bb97b30d07e72322