### PR TITLE
Document Node requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ This repository contains the code for the **Dark Souls Minimal Cheat Sheet**. Th
 
 All files are static HTML, CSS and JavaScript. Clone the repo and open `index.html` in your browser to run it locally.
 
+Development and the test suite expect **Node.js 20** or newer. You can check your installed version with `node --version`.
+
 ## Running Tests
 
-A small QUnit test suite validates the client-side logic. Install dependencies and run the tests with:
+A small QUnit test suite validates the client-side logic. Install dependencies with `npm install` (or `npm ci` when using a lockfile) and run the tests with:
 
 ```bash
 npm install

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "Dark Souls Minimal Cheat Sheet",
   "repository": "https://github.com/Vesylum/dark-souls-minimal-cheat-sheet",
+  "engines": {
+    "node": ">=20"
+  },
   "devDependencies": {
     "qunit": "^2.20.0",
     "jsdom": "^22.1.0",


### PR DESCRIPTION
## Summary
- document Node.js 20 requirement in README
- mention using `npm ci` for lockfile installs
- require Node 20+ in `package.json`

## Testing
- `npm test` *(fails: qunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e0e654b88321b66405788f3356ca