### PR TITLE
Add progress reset button and tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
                         </select>
                         <button class="btn" type="button" id="profileAdd">Add</button>
                         <button class="btn" type="button" id="profileEdit">Edit</button>
+                        <button class="btn btn-danger" type="button" id="progressReset">Reset Progress</button>
                    </div>
                 </div>
             </div>

--- a/js/main.js
+++ b/js/main.js
@@ -57,6 +57,10 @@
             $('#profileModal').modal('show');
         });
 
+        $('#progressReset').click(function() {
+            resetProgress();
+        });
+
         $('#profileModalAdd').click(function(event) {
             event.preventDefault();
             var profile = $.trim($('#profileModalName').val());
@@ -175,6 +179,18 @@
         }
     }
 
+    function resetProgress() {
+        if ($.jStorage.flush) {
+            $.jStorage.flush();
+        } else {
+            $.jStorage.deleteKey(profilesKey);
+        }
+        profiles = $.extend(true, {}, defaultProfiles);
+        $.jStorage.set(profilesKey, profiles);
+        populateProfiles();
+        populateChecklists();
+    }
+
     function canDelete() {
         var count = 0;
         $.each(profiles[profilesKey], function(index, value) {
@@ -189,9 +205,10 @@
         }
     }
 
-    // Expose calculateTotals for testing
+    // Expose functions for testing
     if (typeof window !== 'undefined') {
         window.calculateTotals = calculateTotals;
+        window.resetProgress = resetProgress;
     }
 
 })( jQuery );

--- a/tests/resetProgress.test.js
+++ b/tests/resetProgress.test.js
@@ -1,0 +1,49 @@
+const { JSDOM } = require('jsdom');
+const QUnit = require('qunit');
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+const { window } = dom;
+global.window = window;
+global.document = window.document;
+
+const $ = require('jquery')(window);
+global.$ = global.jQuery = $;
+
+let flushed = false;
+$.jStorage = {
+  get: (_key, def) => ({
+    current: 'Default Profile',
+    profiles: {
+      'Default Profile': {
+        checklistData: { 'foo_1_1': true }
+      }
+    }
+  }),
+  set: () => {},
+  flush: () => { flushed = true; }
+};
+
+global.profilesKey = 'profiles';
+
+require('../js/main.js');
+
+QUnit.module('resetProgress');
+
+QUnit.test('clears progress and totals', assert => {
+  const html = `
+    <span id="foo_overall_total"></span>
+    <span id="foo_totals_1"></span>
+    <span id="foo_nav_totals_1"></span>
+    <input type="checkbox" id="foo_1_1" checked>
+  `;
+  document.body.innerHTML = html;
+
+  window.calculateTotals();
+  assert.strictEqual(document.getElementById('foo_overall_total').textContent, '[1/1]');
+  assert.ok(document.getElementById('foo_1_1').checked);
+
+  window.resetProgress();
+  assert.ok(flushed, 'storage flushed');
+  assert.strictEqual(document.getElementById('foo_1_1').checked, false);
+  assert.strictEqual(document.getElementById('foo_overall_total').textContent, '[0/1]');
+});


### PR DESCRIPTION
## Summary
- add a Reset Progress button next to profile management
- hook up resetProgress handler in main.js
- expose resetProgress for tests
- test progress reset behavior with QUnit

## Testing
- `npm test` *(fails: qunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e0fa63988321aac37cac330b0527