### PR TITLE
Add profilesKey fallback and update tests

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,8 @@
 (function($) {
     "use strict";
 
+    var profilesKey = window.profilesKey || 'profiles';
+
     var defaultProfiles = {
         'current': 'Default Profile'
     };

--- a/tests/calculateTotals.test.js
+++ b/tests/calculateTotals.test.js
@@ -16,9 +16,6 @@ $.jStorage = {
   set: () => {}
 };
 
-// Global variable required by main.js
-global.profilesKey = 'profiles';
-
 // Load script which attaches calculateTotals to window
 require('../js/main.js');
 

--- a/tests/resetProgress.test.js
+++ b/tests/resetProgress.test.js
@@ -23,8 +23,6 @@ $.jStorage = {
   flush: () => { flushed = true; }
 };
 
-global.profilesKey = 'profiles';
-
 require('../js/main.js');
 
 QUnit.module('resetProgress');


### PR DESCRIPTION
## Summary
- set a default `profilesKey` if none is defined on `window`
- remove explicit `profilesKey` setup from tests to verify default handling

## Testing
- `npm test` *(fails: qunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e5aaff50832189866ecc954779d2