### PR TITLE
Use deleteKey to reset profiles

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -182,11 +182,7 @@
     }
 
     function resetProgress() {
-        if ($.jStorage.flush) {
-            $.jStorage.flush();
-        } else {
-            $.jStorage.deleteKey(profilesKey);
-        }
+        $.jStorage.deleteKey(profilesKey);
         profiles = $.extend(true, {}, defaultProfiles);
         $.jStorage.set(profilesKey, profiles);
         populateProfiles();

--- a/tests/resetProgress.test.js
+++ b/tests/resetProgress.test.js
@@ -9,7 +9,7 @@ global.document = window.document;
 const $ = require('jquery')(window);
 global.$ = global.jQuery = $;
 
-let flushed = false;
+let deleted = false;
 $.jStorage = {
   get: (_key, def) => ({
     current: 'Default Profile',
@@ -20,7 +20,7 @@ $.jStorage = {
     }
   }),
   set: () => {},
-  flush: () => { flushed = true; }
+  deleteKey: () => { deleted = true; }
 };
 
 require('../js/main.js');
@@ -41,7 +41,7 @@ QUnit.test('clears progress and totals', assert => {
   assert.ok(document.getElementById('foo_1_1').checked);
 
   window.resetProgress();
-  assert.ok(flushed, 'storage flushed');
+  assert.ok(deleted, 'storage cleared');
   assert.strictEqual(document.getElementById('foo_1_1').checked, false);
   assert.strictEqual(document.getElementById('foo_overall_total').textContent, '[0/1]');
 });


### PR DESCRIPTION
## Summary
- always use `$.jStorage.deleteKey` when resetting progress
- update tests to check that storage is cleared via `deleteKey`

## Testing
- `npm test` *(fails: qunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e6fabef083218a65f831aeff4d39