### PR TITLE
Fix test script path

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "jquery": "^3.7.1"
   },
   "scripts": {
-    "test": "qunit"
+    "test": "qunit tests"
   }
 }

--- a/tests/calculateTotals.test.js
+++ b/tests/calculateTotals.test.js
@@ -7,7 +7,7 @@ const { window } = dom;
 global.window = window;
 global.document = window.document;
 // jQuery setup
-const $ = require('jquery')(window);
+const $ = require('jquery');
 global.$ = global.jQuery = $;
 
 // Stub jStorage used by main.js

--- a/tests/resetProgress.test.js
+++ b/tests/resetProgress.test.js
@@ -6,7 +6,7 @@ const { window } = dom;
 global.window = window;
 global.document = window.document;
 
-const $ = require('jquery')(window);
+const $ = require('jquery');
 global.$ = global.jQuery = $;
 
 let deleted = false;


### PR DESCRIPTION
## Summary
- update test script in package.json to run tests from the `tests` folder
- adjust test setup to load jQuery correctly

## Testing
- `npm test` *(fails: calculateTotals and resetProgress tests run but fail)*

------
https://chatgpt.com/codex/tasks/task_e_6845ecd710e88321a4cf3ce472cef4ab