### PR TITLE
Fix reset progress test

### DIFF
--- a/tests/resetProgress.test.js
+++ b/tests/resetProgress.test.js
@@ -37,7 +37,7 @@ QUnit.test('clears progress and totals', assert => {
   document.body.innerHTML = html;
 
   window.calculateTotals();
-  assert.strictEqual(document.getElementById('foo_overall_total').textContent, '[1/1]');
+  assert.strictEqual(document.getElementById('foo_overall_total').textContent, '[DONE]');
   assert.ok(document.getElementById('foo_1_1').checked);
 
   window.resetProgress();


### PR DESCRIPTION
## Summary
- update expectation for cleared totals in `resetProgress.test.js`

## Testing
- `npx qunit tests/resetProgress.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6845f54e81c88321af667d3f57a0e46e