### PR TITLE
Reset jQuery instances between tests

### DIFF
--- a/tests/calculateTotals.test.js
+++ b/tests/calculateTotals.test.js
@@ -1,25 +1,35 @@
 const { JSDOM } = require('jsdom');
 const QUnit = require('qunit');
 
-// Setup DOM
-const dom = new JSDOM('<!doctype html><html><body></body></html>');
-const { window } = dom;
-global.window = window;
-global.document = window.document;
-// jQuery setup
-const $ = require('jquery');
-global.$ = global.jQuery = $;
+let $;
 
-// Stub jStorage used by main.js
-$.jStorage = {
-  get: (_key, def) => def,
-  set: () => {}
-};
+QUnit.module('calculateTotals', hooks => {
+  hooks.beforeEach(() => {
+    const dom = new JSDOM('<!doctype html><html><body></body></html>');
+    const { window } = dom;
+    global.window = window;
+    global.document = window.document;
 
-// Load script which attaches calculateTotals to window
-require('../js/main.js');
+    delete require.cache[require.resolve('jquery')];
+    $ = require('jquery');
+    global.$ = global.jQuery = $;
+    document.dispatchEvent(new window.Event('DOMContentLoaded'));
 
-QUnit.module('calculateTotals');
+    $.jStorage = {
+      get: (_key, def) => def,
+      set: () => {}
+    };
+
+    delete require.cache[require.resolve('../js/main.js')];
+    require('../js/main.js');
+    return new Promise(r => setTimeout(r, 50));
+  });
+
+  hooks.afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.$;
+  });
 
 QUnit.test('updates totals based on checkbox states', assert => {
   const html = `
@@ -41,4 +51,6 @@ QUnit.test('updates totals based on checkbox states', assert => {
   assert.strictEqual(document.getElementById('foo_totals_1').textContent, '[DONE]');
   assert.strictEqual(document.getElementById('foo_nav_totals_1').textContent, '[DONE]');
   assert.strictEqual(document.getElementById('foo_overall_total').textContent, '[DONE]');
+});
+
 });

--- a/tests/profileRename.test.js
+++ b/tests/profileRename.test.js
@@ -1,40 +1,53 @@
 const { JSDOM } = require('jsdom');
 const QUnit = require('qunit');
 
-// Setup DOM with required elements before loading script
-const dom = new JSDOM('<!doctype html><html><body>\n'
-  + '<input id="profileModalName">\n'
-  + '<div id="profileModal"></div>\n'
-  + '<select id="profiles"></select>\n'
-  + '<a id="profileModalUpdate"></a>\n'
-  + '</body></html>');
-const { window } = dom;
-global.window = window;
-global.document = window.document;
+let $;
+let store;
+let alertCalled;
 
-const $ = require('jquery');
-global.$ = global.jQuery = $;
+QUnit.module('profile rename', hooks => {
+  hooks.beforeEach(() => {
+    const dom = new JSDOM('<!doctype html><html><body>\n'
+      + '<input id="profileModalName">\n'
+      + '<div id="profileModal"></div>\n'
+      + '<select id="profiles"></select>\n'
+      + '<a id="profileModalUpdate"></a>\n'
+      + '</body></html>');
+    const { window } = dom;
+    global.window = window;
+    global.document = window.document;
 
-// stub bootstrap modal
-$.fn.modal = () => {};
+    delete require.cache[require.resolve('jquery')];
+    $ = require('jquery');
+    global.$ = global.jQuery = $;
+    document.dispatchEvent(new window.Event('DOMContentLoaded'));
+    $.fn.modal = () => {};
 
-let store = { current: 'Default Profile' };
-store['profiles'] = {
-  'Default Profile': { checklistData: {} },
-  'Existing': { checklistData: {} }
-};
+    store = { current: 'Default Profile' };
+    store['profiles'] = {
+      'Default Profile': { checklistData: {} },
+      'Existing': { checklistData: {} }
+    };
 
-$.jStorage = {
-  get: () => store,
-  set: (_key, val) => { store = val; }
-};
+    $.jStorage = {
+      get: () => store,
+      set: (_key, val) => { store = val; }
+    };
 
-let alertCalled = false;
-window.alert = () => { alertCalled = true; };
+    alertCalled = false;
+    global.alert = () => { alertCalled = true; };
+    alert = global.alert; // expose as global variable for strict mode
 
-require('../js/main.js');
+    delete require.cache[require.resolve('../js/main.js')];
+    require('../js/main.js');
+    return new Promise(r => setTimeout(r, 50));
+  });
 
-QUnit.module('profile rename');
+  hooks.afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.$;
+  });
 
 QUnit.test('alert when renaming to existing profile', assert => {
   $('#profileModalName').val('Existing');
@@ -43,4 +56,6 @@ QUnit.test('alert when renaming to existing profile', assert => {
   assert.strictEqual(store.current, 'Default Profile', 'current profile unchanged');
   assert.ok(store.profiles['Default Profile'], 'original profile kept');
   assert.ok(store.profiles['Existing'], 'existing profile kept');
+});
+
 });

--- a/tests/resetProgress.test.js
+++ b/tests/resetProgress.test.js
@@ -1,31 +1,45 @@
 const { JSDOM } = require('jsdom');
 const QUnit = require('qunit');
 
-const dom = new JSDOM('<!doctype html><html><body></body></html>');
-const { window } = dom;
-global.window = window;
-global.document = window.document;
+let $;
+let deleted;
 
-const $ = require('jquery');
-global.$ = global.jQuery = $;
+QUnit.module('resetProgress', hooks => {
+  hooks.beforeEach(() => {
+    const dom = new JSDOM('<!doctype html><html><body></body></html>');
+    const { window } = dom;
+    global.window = window;
+    global.document = window.document;
 
-let deleted = false;
-$.jStorage = {
-  get: (_key, def) => ({
-    current: 'Default Profile',
-    profiles: {
-      'Default Profile': {
-        checklistData: { 'foo_1_1': true }
-      }
-    }
-  }),
-  set: () => {},
-  deleteKey: () => { deleted = true; }
-};
+    delete require.cache[require.resolve('jquery')];
+    $ = require('jquery');
+    global.$ = global.jQuery = $;
+    document.dispatchEvent(new window.Event('DOMContentLoaded'));
 
-require('../js/main.js');
+    deleted = false;
+    $.jStorage = {
+      get: (_key, def) => ({
+        current: 'Default Profile',
+        profiles: {
+          'Default Profile': {
+            checklistData: { 'foo_1_1': true }
+          }
+        }
+      }),
+      set: () => {},
+      deleteKey: () => { deleted = true; }
+    };
 
-QUnit.module('resetProgress');
+    delete require.cache[require.resolve('../js/main.js')];
+    require('../js/main.js');
+    return new Promise(r => setTimeout(r, 50));
+  });
+
+  hooks.afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.$;
+  });
 
 QUnit.test('clears progress and totals', assert => {
   const html = `
@@ -37,11 +51,13 @@ QUnit.test('clears progress and totals', assert => {
   document.body.innerHTML = html;
 
   window.calculateTotals();
-  assert.strictEqual(document.getElementById('foo_overall_total').textContent, '[1/1]');
+  assert.strictEqual(document.getElementById('foo_overall_total').textContent, '[DONE]');
   assert.ok(document.getElementById('foo_1_1').checked);
 
   window.resetProgress();
   assert.ok(deleted, 'storage cleared');
   assert.strictEqual(document.getElementById('foo_1_1').checked, false);
   assert.strictEqual(document.getElementById('foo_overall_total').textContent, '[0/1]');
+});
+
 });


### PR DESCRIPTION
## Summary
- ensure each test gets a fresh jQuery by clearing its cache
- rebuild DOM and globals in beforeEach
- fix resetProgress expectation to match script output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845f53de6c48321b236caadf9c35a2c