### PR TITLE
Refactor addCheckbox DOM usage

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -205,12 +205,25 @@
     }
 
     function addCheckbox(el) {
-        const $el = $(el);
-        const lines = $el.html().split('\n');
-        lines[0] = '<label class="checkbox"><input type="checkbox" id="' + $el.attr('data-id') + '">' + lines[0] + '</label>';
-        $el.html(lines.join('\n'));
-        if (profiles[profilesKey][profiles.current].checklistData[$el.attr('data-id')] == true) {
-            $('#' + $el.attr('data-id')).prop('checked', true);
+        const id = el.getAttribute('data-id');
+
+        const label = document.createElement('label');
+        label.className = 'checkbox';
+
+        const input = document.createElement('input');
+        input.type = 'checkbox';
+        input.id = id;
+        label.appendChild(input);
+
+        // Move existing nodes (until a child list) into the label
+        while (el.firstChild && !(el.firstChild.nodeType === 1 && el.firstChild.tagName === 'UL')) {
+            label.appendChild(el.firstChild);
+        }
+
+        el.insertBefore(label, el.firstChild);
+
+        if (profiles[profilesKey][profiles.current].checklistData[id] === true) {
+            input.checked = true;
         }
     }
 

--- a/tests/addCheckbox.test.js
+++ b/tests/addCheckbox.test.js
@@ -1,0 +1,64 @@
+const { JSDOM } = require('jsdom');
+const QUnit = require('qunit');
+
+let $;
+
+QUnit.module('addCheckbox', hooks => {
+  hooks.beforeEach(() => {
+    const dom = new JSDOM('<!doctype html><html><body>' +
+      '<div id="playthrough_sections"></div>' +
+      '<ul id="playthrough_nav"></ul>' +
+      '</body></html>', { url: 'http://localhost' });
+    const { window } = dom;
+    global.window = window;
+    global.document = window.document;
+
+    delete require.cache[require.resolve('jquery')];
+    $ = require('jquery');
+    global.$ = global.jQuery = $;
+    document.dispatchEvent(new window.Event('DOMContentLoaded'));
+
+    $.getJSON = (_url, cb) => {
+      cb([
+        {
+          id: 'section1',
+          title: 'Section 1',
+          items: [
+            {
+              id: 'foo_1_1',
+              content: 'Item 1',
+              children: [ { id: 'foo_1_1_1', content: 'Child' } ]
+            }
+          ]
+        }
+      ]);
+    };
+
+    delete require.cache[require.resolve('../js/main.js')];
+    require('../js/main.js');
+    return new Promise(r => setTimeout(r, 50));
+  });
+
+  hooks.afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.$;
+  });
+
+  QUnit.test('checkbox and label inserted correctly', assert => {
+    const li = document.querySelector('li[data-id="foo_1_1"]');
+    assert.ok(li, 'li exists');
+    const label = li.firstElementChild;
+    assert.strictEqual(label.tagName, 'LABEL');
+    assert.strictEqual(label.className, 'checkbox');
+    const input = label.firstElementChild;
+    assert.strictEqual(input.tagName, 'INPUT');
+    assert.strictEqual(input.type, 'checkbox');
+    assert.strictEqual(input.id, 'foo_1_1');
+    assert.ok(label.textContent.includes('Item 1'));
+
+    const childUl = li.querySelector('ul');
+    assert.ok(childUl, 'child ul exists');
+    assert.strictEqual(childUl.parentElement, li, 'child ul not inside label');
+  });
+});


### PR DESCRIPTION
## Summary
- refactor `addCheckbox` to build labels and checkboxes using DOM APIs
- add tests covering the updated `addCheckbox` behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68460745a24083218ff44fd6999d3491