### PR TITLE
Add profile helper tests

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -295,6 +295,8 @@
         window.resetProgress = resetProgress;
         window.populateProfiles = populateProfiles;
         window.populateChecklists = populateChecklists;
+        window.canDelete = canDelete;
+        window.getFirstProfile = getFirstProfile;
     }
 
 })( jQuery );

--- a/tests/profileUtils.test.js
+++ b/tests/profileUtils.test.js
@@ -1,0 +1,71 @@
+const { JSDOM } = require('jsdom');
+const QUnit = require('qunit');
+
+let $;
+
+async function setup(store) {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost' });
+  const { window } = dom;
+  global.window = window;
+  global.document = window.document;
+
+  delete require.cache[require.resolve('jquery')];
+  $ = require('jquery');
+  global.$ = global.jQuery = $;
+  document.dispatchEvent(new window.Event('DOMContentLoaded'));
+
+  $.getJSON = (_url, cb) => { cb({}); };
+
+  window.localStorage.setItem('profiles', JSON.stringify(store));
+
+  delete require.cache[require.resolve('../js/main.js')];
+  require('../js/main.js');
+  await new Promise(r => setTimeout(r, 50));
+}
+
+function teardown() {
+  delete global.window;
+  delete global.document;
+  delete global.$;
+}
+
+QUnit.module('profile util functions');
+
+QUnit.test('canDelete returns false with one profile', async assert => {
+  const store = {
+    current: 'Only',
+    profiles: {
+      'Only': { checklistData: {} }
+    }
+  };
+  await setup(store);
+  assert.notOk(window.canDelete(), 'should not allow delete with one profile');
+  teardown();
+});
+
+QUnit.test('canDelete returns true with multiple profiles', async assert => {
+  const store = {
+    current: 'Profile1',
+    profiles: {
+      'Profile1': { checklistData: {} },
+      'Profile2': { checklistData: {} }
+    }
+  };
+  await setup(store);
+  assert.ok(window.canDelete(), 'allows delete with multiple profiles');
+  teardown();
+});
+
+QUnit.test('getFirstProfile returns the first profile name', async assert => {
+  const store = {
+    current: 'B',
+    profiles: {
+      'A': { checklistData: {} },
+      'B': { checklistData: {} },
+      'C': { checklistData: {} }
+    }
+  };
+  await setup(store);
+  assert.strictEqual(window.getFirstProfile(), 'A');
+  teardown();
+});


### PR DESCRIPTION
## Summary
- expose `canDelete` and `getFirstProfile` for tests
- add QUnit tests for these helper functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68460746baf48321b4b820428298c00d