### PR TITLE
Handle loading errors for playthrough data

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -250,11 +250,20 @@
     }
 
     function loadPlaythrough() {
-        $.getJSON('data/playthrough.json', function(data) {
+        const request = $.getJSON('data/playthrough.json', function(data) {
             renderPlaythrough(data);
             $('li[data-id]').each(function () { addCheckbox(this); });
             populateChecklists();
         });
+        if (request && typeof request.fail === 'function') {
+            request.fail(function() {
+                const msg = 'Failed to load playthrough data';
+                alert(msg);
+                $('#playthrough_sections').html(
+                    '<p class="text-danger">' + msg + '</p>'
+                );
+            });
+        }
     }
 
     function renderPlaythrough(sections) {


### PR DESCRIPTION
## Summary
- handle AJAX errors when loading `playthrough.json`
- alert the user and show an error message in the page when the request fails

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68460a4a558883218766762b97388070