### PR TITLE
Add progress export/import feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ npm test
 
 The tests execute under Node.js using jsdom to simulate a browser environment.
 
+## Exporting and Importing Progress
+
+The site stores your checklist data in the browser. Click **Export Progress** to
+copy it as a JSON string. Use **Import Progress** to paste that string into
+another browser or after clearing your storage to restore your progress.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/index.html
+++ b/index.html
@@ -53,6 +53,8 @@
                         <button class="btn" type="button" id="profileAdd">Add</button>
                         <button class="btn" type="button" id="profileEdit">Edit</button>
                         <button class="btn btn-danger" type="button" id="progressReset">Reset Progress</button>
+                        <button class="btn" type="button" id="progressExport">Export Progress</button>
+                        <button class="btn" type="button" id="progressImport">Import Progress</button>
                    </div>
                 </div>
             </div>

--- a/js/main.js
+++ b/js/main.js
@@ -84,6 +84,20 @@
             resetProgress();
         });
 
+        $('#progressExport').click(function() {
+            const data = serializeProfiles();
+            window.prompt('Copy your progress JSON', data);
+        });
+
+        $('#progressImport').click(function() {
+            const data = window.prompt('Paste progress JSON to import');
+            if (data) {
+                if (!restoreProfiles(data)) {
+                    alert('Invalid progress data');
+                }
+            }
+        });
+
         $('#profileModalAdd').click(function(event) {
             event.preventDefault();
             const $name = $('#profileModalName');
@@ -235,6 +249,27 @@
         populateChecklists();
     }
 
+    function serializeProfiles() {
+        return JSON.stringify(profiles);
+    }
+
+    function restoreProfiles(json) {
+        let data;
+        try {
+            data = JSON.parse(json);
+        } catch (e) {
+            return false;
+        }
+        if (!data || typeof data !== 'object' || !(profilesKey in data)) {
+            return false;
+        }
+        profiles = data;
+        storageSet(profilesKey, profiles);
+        populateProfiles();
+        populateChecklists();
+        return true;
+    }
+
     function canDelete() {
         let count = 0;
         $.each(profiles[profilesKey], function(index, value) {
@@ -306,6 +341,8 @@
     if (typeof window !== 'undefined') {
         window.calculateTotals = calculateTotals;
         window.resetProgress = resetProgress;
+        window.serializeProfiles = serializeProfiles;
+        window.restoreProfiles = restoreProfiles;
         window.populateProfiles = populateProfiles;
         window.populateChecklists = populateChecklists;
         window.canDelete = canDelete;

--- a/tests/exportImport.test.js
+++ b/tests/exportImport.test.js
@@ -1,0 +1,66 @@
+const { JSDOM } = require('jsdom');
+const QUnit = require('qunit');
+
+let $;
+let store1;
+let store2;
+
+QUnit.module('export/import progress', hooks => {
+  hooks.beforeEach(() => {
+    const dom = new JSDOM('<!doctype html><html><body>' +
+      '<div id="playthrough_sections"></div>' +
+      '<ul id="playthrough_nav"></ul>' +
+      '<select id="profiles"></select>' +
+      '<input type="checkbox" id="foo_1_1">' +
+      '<input type="checkbox" id="foo_1_2">' +
+      '</body></html>', { url: 'http://localhost' });
+    const { window } = dom;
+    global.window = window;
+    global.document = window.document;
+
+    delete require.cache[require.resolve('jquery')];
+    $ = require('jquery');
+    global.$ = global.jQuery = $;
+    document.dispatchEvent(new window.Event('DOMContentLoaded'));
+
+    $.getJSON = (_url, cb) => { cb({}); };
+
+    store1 = { current: 'Profile1' };
+    store1['profiles'] = {
+      'Profile1': { checklistData: { 'foo_1_1': true, 'foo_1_2': false } }
+    };
+    store2 = { current: 'Profile2' };
+    store2['profiles'] = {
+      'Profile2': { checklistData: { 'foo_1_1': false, 'foo_1_2': true } }
+    };
+
+    window.localStorage.setItem('profiles', JSON.stringify(store1));
+
+    delete require.cache[require.resolve('../js/main.js')];
+    require('../js/main.js');
+    return new Promise(r => setTimeout(r, 50));
+  });
+
+  hooks.afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.$;
+  });
+
+  QUnit.test('serializeProfiles returns stored JSON', assert => {
+    const json = window.serializeProfiles();
+    assert.strictEqual(json, JSON.stringify(store1));
+  });
+
+  QUnit.test('restoreProfiles updates store and UI', assert => {
+    assert.notOk(document.getElementById('foo_1_2').checked, 'initial state');
+    const ok = window.restoreProfiles(JSON.stringify(store2));
+    assert.ok(ok, 'restore success');
+
+    const saved = JSON.parse(window.localStorage.getItem('profiles'));
+    assert.deepEqual(saved, store2, 'localStorage updated');
+    assert.strictEqual(document.getElementById('profiles').value, 'Profile2', 'profile select updated');
+    assert.ok(document.getElementById('foo_1_2').checked, 'checkbox updated');
+    assert.notOk(document.getElementById('foo_1_1').checked, 'checkbox updated');
+  });
+});


### PR DESCRIPTION
## Summary
- extend `main.js` with serializeProfiles and restoreProfiles
- expose new functions for testing
- hook up Export/Import buttons in the UI
- document usage in README
- test progress serialization and restoration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68460a5ad7ac8321bfd4f501867a8a6b