### PR TITLE
Fix default profile cloning and add regression test

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -4,12 +4,12 @@
     function storageGet(key, def) {
         const val = window.localStorage.getItem(key);
         if (val === null) {
-            return def;
+            return $.extend(true, {}, def);
         }
         try {
             return JSON.parse(val);
         } catch (e) {
-            return def;
+            return $.extend(true, {}, def);
         }
     }
 

--- a/tests/defaultProfilesClone.test.js
+++ b/tests/defaultProfilesClone.test.js
@@ -1,0 +1,45 @@
+const { JSDOM } = require('jsdom');
+const QUnit = require('qunit');
+
+let $;
+
+QUnit.module('defaultProfiles clone', hooks => {
+  hooks.beforeEach(() => {
+    const dom = new JSDOM('<!doctype html><html><body>' +
+      '<input type="checkbox" id="foo_1_1">' +
+      '</body></html>', { url: 'http://localhost' });
+    const { window } = dom;
+    global.window = window;
+    global.document = window.document;
+
+    delete require.cache[require.resolve('jquery')];
+    $ = require('jquery');
+    global.$ = global.jQuery = $;
+    document.dispatchEvent(new window.Event('DOMContentLoaded'));
+
+    $.getJSON = (_url, cb) => { setTimeout(() => cb({}), 0); };
+
+    delete require.cache[require.resolve('../js/main.js')];
+    require('../js/main.js');
+    return new Promise(r => setTimeout(r, 50));
+  });
+
+  hooks.afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.$;
+  });
+
+  QUnit.test('resetProgress should clear stored checklist data', assert => {
+    const checkbox = document.getElementById('foo_1_1');
+    $(checkbox).trigger('click');
+
+    let store = JSON.parse(window.localStorage.getItem('profiles'));
+    assert.ok(store.profiles['Default Profile'].checklistData['foo_1_1'], 'progress saved');
+
+    window.resetProgress();
+
+    store = JSON.parse(window.localStorage.getItem('profiles'));
+    assert.deepEqual(store.profiles['Default Profile'].checklistData, {}, 'checklist cleared');
+  });
+});


### PR DESCRIPTION
## Summary
- clone default profiles in `storageGet`
- verify `resetProgress` clears data when starting from defaults

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846124c447c8321ba34570ec165357a