### PR TITLE
Validate current profile on import

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -263,6 +263,12 @@
         if (!data || typeof data !== 'object' || !(profilesKey in data)) {
             return false;
         }
+        if (typeof data.current !== 'string') {
+            return false;
+        }
+        if (!(data.current in data[profilesKey])) {
+            return false;
+        }
         profiles = data;
         storageSet(profilesKey, profiles);
         populateProfiles();

--- a/tests/exportImport.test.js
+++ b/tests/exportImport.test.js
@@ -63,4 +63,14 @@ QUnit.module('export/import progress', hooks => {
     assert.ok(document.getElementById('foo_1_2').checked, 'checkbox updated');
     assert.notOk(document.getElementById('foo_1_1').checked, 'checkbox updated');
   });
+
+  QUnit.test('restoreProfiles rejects invalid current', assert => {
+    const invalid = { current: 'Missing', profiles: { 'Profile1': { checklistData: {} } } };
+    const before = JSON.parse(window.localStorage.getItem('profiles'));
+    const ok = window.restoreProfiles(JSON.stringify(invalid));
+    assert.notOk(ok, 'restore failed');
+    const after = JSON.parse(window.localStorage.getItem('profiles'));
+    assert.deepEqual(after, before, 'localStorage unchanged');
+    assert.strictEqual(document.getElementById('profiles').value, 'Profile1', 'profile select unchanged');
+  });
 });


### PR DESCRIPTION
## Summary
- verify the imported data has a valid `current` profile
- test restoreProfiles rejects invalid data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846150fef78832195d5d12c1f06ecd4