### PR TITLE
Use change handler for checkbox updates

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -38,7 +38,7 @@
         loadPlaythrough();
         populateProfiles();
 
-        $(document).on('click', 'input[type="checkbox"]', function () {
+        $(document).on('change', 'input[type="checkbox"]', function () {
             const $checkbox = $(this);
             const id = $checkbox.attr('id');
             const isChecked = profiles[profilesKey][profiles.current].checklistData[id] = $checkbox.prop('checked');

--- a/tests/addCheckbox.test.js
+++ b/tests/addCheckbox.test.js
@@ -65,7 +65,7 @@ QUnit.module('addCheckbox', hooks => {
   QUnit.test('clicking dynamically created checkbox updates profiles', assert => {
     const checkbox = document.getElementById('foo_1_1');
     assert.ok(checkbox, 'checkbox exists');
-    $(checkbox).trigger('click');
+    $(checkbox).prop('checked', true).trigger('change');
     const store = JSON.parse(window.localStorage.getItem('profiles'));
     assert.ok(store.profiles['Default Profile'].checklistData['foo_1_1'], 'profile updated');
   });

--- a/tests/defaultProfilesClone.test.js
+++ b/tests/defaultProfilesClone.test.js
@@ -32,7 +32,7 @@ QUnit.module('defaultProfiles clone', hooks => {
 
   QUnit.test('resetProgress should clear stored checklist data', assert => {
     const checkbox = document.getElementById('foo_1_1');
-    $(checkbox).trigger('click');
+    $(checkbox).prop('checked', true).trigger('change');
 
     let store = JSON.parse(window.localStorage.getItem('profiles'));
     assert.ok(store.profiles['Default Profile'].checklistData['foo_1_1'], 'progress saved');


### PR DESCRIPTION
## Summary
- replace click handler in `main.js` with a change handler for checkboxes
- adjust checkbox toggle tests to trigger `change` events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846151d57608321ab9eb2eb05d6cfbf