### PR TITLE
Add npm start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains the code for the **Dark Souls Minimal Cheat Sheet**. Th
 
 ## Development
 
-All files are static HTML, CSS and JavaScript. Clone the repo and serve the directory with a local HTTP server. For example, run `npx serve` or `python -m http.server` in the project root and then open the provided URL in your browser.
+All files are static HTML, CSS and JavaScript. Clone the repo and serve the directory with a local HTTP server. Run `npm start` (which uses `npx serve`) or `python -m http.server` in the project root and then open the provided URL in your browser.
 
 Checklist content now lives in `data/playthrough.json`. This file lists each playthrough section and the items within it. The JavaScript fetches this JSON on page load and generates the checklist dynamically.
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "jquery": "^3.7.1"
   },
   "scripts": {
+    "start": "npx serve",
     "test": "qunit tests"
   }
 }


### PR DESCRIPTION
## Summary
- add a `start` script using `npx serve`
- document the new command in the Development section of the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684617a04f3483218346334a7845beda