### PR TITLE
Add loadPlaythrough failure test

### DIFF
--- a/tests/loadPlaythroughFail.test.js
+++ b/tests/loadPlaythroughFail.test.js
@@ -1,0 +1,45 @@
+const { JSDOM } = require('jsdom');
+const QUnit = require('qunit');
+
+let $;
+let alertCalled;
+
+QUnit.module('loadPlaythrough failure', hooks => {
+  hooks.beforeEach(() => {
+    const dom = new JSDOM('<!doctype html><html><body>' +
+      '<div id="playthrough_sections"></div>' +
+      '</body></html>', { url: 'http://localhost' });
+    const { window } = dom;
+    global.window = window;
+    global.document = window.document;
+
+    delete require.cache[require.resolve('jquery')];
+    $ = require('jquery');
+    global.$ = global.jQuery = $;
+    document.dispatchEvent(new window.Event('DOMContentLoaded'));
+
+    $.getJSON = () => ({
+      fail: cb => { setTimeout(cb, 0); }
+    });
+
+    alertCalled = false;
+    global.alert = () => { alertCalled = true; };
+    alert = global.alert;
+
+    delete require.cache[require.resolve('../js/main.js')];
+    require('../js/main.js');
+    return new Promise(r => setTimeout(r, 50));
+  });
+
+  hooks.afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.$;
+  });
+
+  QUnit.test('shows error and alerts user on JSON fail', assert => {
+    assert.ok(alertCalled, 'alert shown');
+    const html = document.getElementById('playthrough_sections').innerHTML.trim();
+    assert.strictEqual(html, '<p class="text-danger">Failed to load playthrough data</p>');
+  });
+});


### PR DESCRIPTION
## Summary
- test that the playthrough load error message and alert are triggered when `$.getJSON` fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684617a7d9b483219c6180beb4d372e8