### PR TITLE
Fix jQuery fallback test

### DIFF
--- a/tests/jqueryFallback.test.js
+++ b/tests/jqueryFallback.test.js
@@ -17,6 +17,14 @@ QUnit.test('main.js runs with local jQuery when CDN fails', assert => {
     jQueryFactory(window);
   }
 
+  // Prevent jsdom "Not implemented" alert errors
+  window.alert = global.alert = () => {};
+
+  // Stub $.getJSON so no network request is made
+  window.$.getJSON = () => ({
+    fail: cb => { setTimeout(cb, 0); }
+  });
+
   const main = fs.readFileSync('js/main.js', 'utf8');
   window.eval(main);
 


### PR DESCRIPTION
## Summary
- silence `window.alert` in `jqueryFallback` test
- stub `$.getJSON` to simulate AJAX failure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846226255bc8321b7d05b515021a313