### PR TITLE
Fix jQuery fallback logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,9 @@
     <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-2ct7Gh6WijC1ga8zmnjHHirFeB8WYm1E9JGHPa9yK6M=" crossorigin="anonymous"></script>
     <script>
         if (!window.jQuery) {
-            document.write('<script src="js/jquery-3.7.1.min.js"><\\/script>');
+            var script = document.createElement('script');
+            script.src = 'js/jquery-3.7.1.min.js';
+            document.head.appendChild(script);
         }
     </script>
     <script type="text/javascript">

--- a/tests/jqueryFallback.test.js
+++ b/tests/jqueryFallback.test.js
@@ -12,7 +12,16 @@ QUnit.test('main.js runs with local jQuery when CDN fails', assert => {
   });
   const { window } = dom;
 
-  // Simulate CDN failure by loading local jQuery if needed
+  // Simulate CDN failure and run the fallback snippet
+  const fallback = `
+    if (!window.jQuery) {
+      var script = document.createElement('script');
+      script.src = 'js/jquery-3.7.1.min.js';
+      document.head.appendChild(script);
+    }
+  `;
+  window.eval(fallback);
+
   if (!window.jQuery) {
     jQueryFactory(window);
   }


### PR DESCRIPTION
## Summary
- switch jQuery fallback to DOM-based script injection
- adjust jQuery fallback test to execute new script snippet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846226b70608321bbd15ce4a39102b6