### PR TITLE
Prevent duplicate profile creation

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -106,9 +106,11 @@
             const $name = $('#profileModalName');
             const profile = $.trim($name.val());
             if (profile.length > 0) {
-                if (typeof profiles[profilesKey][profile] == 'undefined') {
-                    profiles[profilesKey][profile] = { checklistData: {} };
+                if (typeof profiles[profilesKey][profile] !== 'undefined') {
+                    alert('Profile already exists');
+                    return;
                 }
+                profiles[profilesKey][profile] = { checklistData: {} };
                 profiles.current = profile;
                 storageSet(profilesKey, profiles);
                 populateProfiles();

--- a/tests/profileAddDuplicate.test.js
+++ b/tests/profileAddDuplicate.test.js
@@ -1,0 +1,59 @@
+const { JSDOM } = require('jsdom');
+const QUnit = require('qunit');
+
+let $;
+let store;
+let alertCalled;
+
+QUnit.module('profile add duplicate', hooks => {
+  hooks.beforeEach(() => {
+    const dom = new JSDOM('<!doctype html><html><body>\n' +
+      '<input id="profileModalName">\n' +
+      '<div id="profileModal"></div>\n' +
+      '<select id="profiles"></select>\n' +
+      '<a id="profileModalAdd"></a>\n' +
+      '</body></html>', { url: 'http://localhost' });
+    const { window } = dom;
+    global.window = window;
+    global.document = window.document;
+
+    delete require.cache[require.resolve('jquery')];
+    $ = require('jquery');
+    global.$ = global.jQuery = $;
+    document.dispatchEvent(new window.Event('DOMContentLoaded'));
+    $.getJSON = (_url, cb) => { setTimeout(() => cb({}), 0); };
+    $.fn.modal = () => {};
+
+    store = { current: 'Default Profile' };
+    store['profiles'] = {
+      'Default Profile': { checklistData: {} },
+      'Existing': { checklistData: {} }
+    };
+
+    window.localStorage.setItem('profiles', JSON.stringify(store));
+
+    alertCalled = false;
+    global.alert = () => { alertCalled = true; };
+    alert = global.alert; // expose
+
+    delete require.cache[require.resolve('../js/main.js')];
+    require('../js/main.js');
+    return new Promise(r => setTimeout(r, 50));
+  });
+
+  hooks.afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.$;
+  });
+
+  QUnit.test('alert when adding existing profile', assert => {
+    $('#profileModalName').val('Existing');
+    $('#profileModalAdd').trigger('click');
+    assert.ok(alertCalled, 'alert shown');
+    store = JSON.parse(window.localStorage.getItem('profiles'));
+    assert.strictEqual(store.current, 'Default Profile', 'current profile unchanged');
+    assert.ok(store.profiles['Default Profile'], 'original profile kept');
+    assert.ok(store.profiles['Existing'], 'existing profile kept');
+  });
+});


### PR DESCRIPTION
## Summary
- prevent adding duplicate profiles by alerting the user
- test that duplicate profile add shows an alert and leaves state unchanged

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846274cb11883218946e6265146c119