### PR TITLE
Add loadChecklists failure test

### DIFF
--- a/tests/loadChecklistsFail.test.js
+++ b/tests/loadChecklistsFail.test.js
@@ -1,0 +1,45 @@
+const { JSDOM } = require('jsdom');
+const QUnit = require('qunit');
+
+let $;
+let alertCalled;
+
+QUnit.module('loadChecklists failure', hooks => {
+  hooks.beforeEach(() => {
+    const dom = new JSDOM('<!doctype html><html><body>' +
+      '<div id="checklists"></div>' +
+      '</body></html>', { url: 'http://localhost' });
+    const { window } = dom;
+    global.window = window;
+    global.document = window.document;
+
+    delete require.cache[require.resolve('jquery')];
+    $ = require('jquery');
+    global.$ = global.jQuery = $;
+    document.dispatchEvent(new window.Event('DOMContentLoaded'));
+
+    $.getJSON = () => ({
+      fail: cb => { setTimeout(cb, 0); }
+    });
+
+    alertCalled = false;
+    global.alert = () => { alertCalled = true; };
+    alert = global.alert;
+
+    delete require.cache[require.resolve('../js/main.js')];
+    require('../js/main.js');
+    return new Promise(r => setTimeout(r, 50));
+  });
+
+  hooks.afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.$;
+  });
+
+  QUnit.test('shows error and alerts user on JSON fail', assert => {
+    assert.ok(alertCalled, 'alert shown');
+    const html = document.getElementById('checklists').innerHTML.trim();
+    assert.strictEqual(html, '<p class="text-danger">Failed to load checklist data</p>');
+  });
+});


### PR DESCRIPTION
## Summary
- add a new test to cover failing checklist fetch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68462bc8364883219622c5947a963e07