### PR TITLE
Add service worker for offline caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ The site stores your checklist data in the browser. Click **Export Progress** to
 copy it as a JSON string. Use **Import Progress** to paste that string into
 another browser or after clearing your storage to restore your progress.
 
+## Service Worker Cache
+
+The service worker caches `index.html`, CSS, JavaScript and JSON data so the
+site works offline. To force clients to update their cache, change the
+`CACHE_NAME` constant in `service-worker.js`. Older caches with different names
+are deleted during the service worker's `activate` event. You can also manually
+clear storage from your browser's developer tools if needed.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/index.html
+++ b/index.html
@@ -347,5 +347,12 @@
             <a href="#" id="profileModalDelete" class="btn btn-danger">Delete</a>
         </div>
     </div>
+    <script>
+        window.onload = function() {
+            if ('serviceWorker' in navigator) {
+                navigator.serviceWorker.register('service-worker.js');
+            }
+        };
+    </script>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,35 @@
+const CACHE_NAME = 'dsmcs-cache-v1';
+const ASSETS_TO_CACHE = [
+  '/',
+  'index.html',
+  'css/bootstrap.min.css',
+  'css/bootstrap-responsive.min.css',
+  'css/main.css',
+  'js/bootstrap.min.js',
+  'js/jquery-3.7.1.min.js',
+  'js/main.js',
+  'data/playthrough.json',
+  'data/checklists.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS_TO_CACHE))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+      )
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- implement `service-worker.js` caching HTML, CSS, JS and JSON files
- register the service worker in `index.html`
- document cache invalidation in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68462e72b5708321b71a5484b1044490