### PR TITLE
Improve accessibility of generated checkboxes

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -228,6 +228,7 @@
 
         const label = document.createElement('label');
         label.className = 'checkbox';
+        label.htmlFor = id;
 
         const input = document.createElement('input');
         input.type = 'checkbox';
@@ -238,6 +239,8 @@
         while (el.firstChild && !(el.firstChild.nodeType === 1 && el.firstChild.tagName === 'UL')) {
             label.appendChild(el.firstChild);
         }
+
+        input.setAttribute('aria-label', label.textContent.trim());
 
         el.insertBefore(label, el.firstChild);
 

--- a/tests/addCheckbox.test.js
+++ b/tests/addCheckbox.test.js
@@ -62,6 +62,13 @@ QUnit.module('addCheckbox', hooks => {
     assert.strictEqual(childUl.parentElement, li, 'child ul not inside label');
   });
 
+  QUnit.test('accessibility attributes are added', assert => {
+    const label = document.querySelector('li[data-id="foo_1_1"] > label');
+    const input = label.firstElementChild;
+    assert.strictEqual(label.htmlFor, 'foo_1_1', 'label htmlFor set');
+    assert.strictEqual(input.getAttribute('aria-label'), 'Item 1', 'aria-label set');
+  });
+
   QUnit.test('clicking dynamically created checkbox updates profiles', assert => {
     const checkbox = document.getElementById('foo_1_1');
     assert.ok(checkbox, 'checkbox exists');


### PR DESCRIPTION
## Summary
- associate labels with checkboxes using `htmlFor`
- add `aria-label` to dynamically created checkboxes
- test the new accessibility attributes

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68462e74b58083218ae816d98d7df7b7