### PR TITLE
Fix service worker cache paths for subfolder deployment

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,6 @@
 const CACHE_NAME = 'dsmcs-cache-v1';
 const ASSETS_TO_CACHE = [
-  '/',
+  './',
   'index.html',
   'css/bootstrap.min.css',
   'css/bootstrap-responsive.min.css',


### PR DESCRIPTION
## Summary
- ensure cached URLs are relative in `service-worker.js`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684631b02abc8321820aa5b16d55935a