### PR TITLE
Fix jQuery fallback load order

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
         if (!window.jQuery) {
             var script = document.createElement('script');
             script.src = 'js/jquery-3.7.1.min.js';
+            script.defer = true;
             document.head.appendChild(script);
         }
     </script>

--- a/tests/jqueryFallback.test.js
+++ b/tests/jqueryFallback.test.js
@@ -17,6 +17,7 @@ QUnit.test('main.js runs with local jQuery when CDN fails', assert => {
     if (!window.jQuery) {
       var script = document.createElement('script');
       script.src = 'js/jquery-3.7.1.min.js';
+      script.defer = true;
       document.head.appendChild(script);
     }
   `;


### PR DESCRIPTION
## Summary
- ensure the fallback jQuery script is deferred
- update fallback test

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684631ba14208321bf15c95160121240