### PR TITLE
Fix global alert cleanup in tests

### DIFF
--- a/tests/exportImport.test.js
+++ b/tests/exportImport.test.js
@@ -46,6 +46,8 @@ QUnit.module('export/import progress', hooks => {
     delete global.window;
     delete global.document;
     delete global.$;
+    delete global.alert;
+    delete global.prompt;
   });
 
   QUnit.test('serializeProfiles returns stored JSON', assert => {

--- a/tests/loadChecklistsFail.test.js
+++ b/tests/loadChecklistsFail.test.js
@@ -35,6 +35,7 @@ QUnit.module('loadChecklists failure', hooks => {
     delete global.window;
     delete global.document;
     delete global.$;
+    delete global.alert;
   });
 
   QUnit.test('shows error and alerts user on JSON fail', assert => {

--- a/tests/loadPlaythroughFail.test.js
+++ b/tests/loadPlaythroughFail.test.js
@@ -35,6 +35,7 @@ QUnit.module('loadPlaythrough failure', hooks => {
     delete global.window;
     delete global.document;
     delete global.$;
+    delete global.alert;
   });
 
   QUnit.test('shows error and alerts user on JSON fail', assert => {

--- a/tests/profileAddDuplicate.test.js
+++ b/tests/profileAddDuplicate.test.js
@@ -45,6 +45,7 @@ QUnit.module('profile add duplicate', hooks => {
     delete global.window;
     delete global.document;
     delete global.$;
+    delete global.alert;
   });
 
   QUnit.test('alert when adding existing profile', assert => {

--- a/tests/profileRename.test.js
+++ b/tests/profileRename.test.js
@@ -45,6 +45,7 @@ QUnit.module('profile rename', hooks => {
     delete global.window;
     delete global.document;
     delete global.$;
+    delete global.alert;
   });
 
 QUnit.test('alert when renaming to existing profile', assert => {


### PR DESCRIPTION
## Summary
- clean up `global.alert` in `afterEach` hooks
- also remove `global.prompt` for export/import tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684634b3313c83219f7397fd1bc4f52d