### PR TITLE
Add manifest to service worker cache

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -9,7 +9,8 @@ const ASSETS_TO_CACHE = [
   'js/jquery-3.7.1.min.js',
   'js/main.js',
   'data/playthrough.json',
-  'data/checklists.json'
+  'data/checklists.json',
+  'manifest.json'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- include `manifest.json` in the cached assets

## Testing
- `npm ci`
- `npm test` *(fails: No tests were run)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684637f269488321b64f4ae2c153f6da