### PR TITLE
Fix corrupted localStorage handling

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -9,6 +9,7 @@
         try {
             return JSON.parse(val);
         } catch (e) {
+            storageDelete(key);
             return $.extend(true, {}, def);
         }
     }


### PR DESCRIPTION
## Summary
- reset saved data if localStorage item fails to parse

## Testing
- `npm test` *(fails: ReferenceError `require` is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684638030c0c8321b1e9739fbb3d48e4