### PR TITLE
Validate profile entries when importing

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -275,9 +275,29 @@
         if (typeof data.current !== 'string') {
             return false;
         }
-        if (!(data.current in data[profilesKey])) {
+
+        const importedProfiles = data[profilesKey];
+        if (!importedProfiles || typeof importedProfiles !== 'object') {
             return false;
         }
+
+        for (const name in importedProfiles) {
+            const entry = importedProfiles[name];
+            if (!entry || typeof entry !== 'object') {
+                return false;
+            }
+            if (!('checklistData' in entry)) {
+                return false;
+            }
+            if (typeof entry.checklistData !== 'object' || entry.checklistData === null) {
+                return false;
+            }
+        }
+
+        if (!(data.current in importedProfiles)) {
+            return false;
+        }
+
         profiles = data;
         storageSet(profilesKey, profiles);
         populateProfiles();

--- a/tests/exportImport.test.js
+++ b/tests/exportImport.test.js
@@ -91,4 +91,23 @@ QUnit.module('export/import progress', hooks => {
     $('#progressImport').trigger('click');
     assert.ok(alertCalled, 'alert shown');
   });
+
+  QUnit.test('restoreProfiles rejects invalid profile structure', assert => {
+    const before = JSON.parse(window.localStorage.getItem('profiles'));
+
+    const invalidProfiles = [
+      { current: 'Profile1', profiles: null },
+      { current: 'Profile1', profiles: [] },
+      { current: 'Profile1', profiles: { 'Profile1': null } },
+      { current: 'Profile1', profiles: { 'Profile1': {} } },
+      { current: 'Profile1', profiles: { 'Profile1': { checklistData: [] } } }
+    ];
+
+    for (const bad of invalidProfiles) {
+      assert.notOk(window.restoreProfiles(JSON.stringify(bad)), 'invalid rejected');
+    }
+
+    const after = JSON.parse(window.localStorage.getItem('profiles'));
+    assert.deepEqual(after, before, 'localStorage unchanged');
+  });
 });


### PR DESCRIPTION
## Summary
- validate each profile entry when restoring progress
- test restoreProfiles with invalid profile data

## Testing
- `npm run lint`
- `npm test` *(fails: Error: Failed to load file tests/addCheckbox.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68463a7637688321a428e65969052707