### PR TITLE
Add versioned cache build step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 
 node_modules/
+service-worker.js

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains the code for the **Dark Souls Minimal Cheat Sheet**. Th
 ## Development
 
 All files are static HTML, CSS and JavaScript. Clone the repo and serve the directory with a local HTTP server. Run `npm start` to launch the locally installed `serve` package, or run `python -m http.server` in the project root and then open the provided URL in your browser.
+Before serving, generate the service worker with `npm run build` so the cache name includes the current version.
 
 Checklist content now lives in `data/playthrough.json`. This file lists each playthrough section and the items within it. The JavaScript fetches this JSON on page load and generates the checklist dynamically.
 Individual sections are collapsible using the native `<details>`/`<summary>` elements with the first section expanded by default.
@@ -35,10 +36,10 @@ another browser or after clearing your storage to restore your progress.
 ## Service Worker Cache
 
 The service worker caches `index.html`, CSS, JavaScript and JSON data so the
-site works offline. To force clients to update their cache, change the
-`CACHE_NAME` constant in `service-worker.js`. Older caches with different names
-are deleted during the service worker's `activate` event. You can also manually
-clear storage from your browser's developer tools if needed.
+site works offline. Run `npm run build` whenever files change to regenerate
+`service-worker.js` with a versioned `CACHE_NAME`. Older caches with different
+names are deleted during the service worker's `activate` event. You can also
+manually clear storage from your browser's developer tools if needed.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "serve": "^14.2.4"
   },
   "scripts": {
+    "build": "node scripts/build.js",
     "start": "npx serve",
     "test": "qunit tests",
     "lint": "eslint js/*.js tests/*.js"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,21 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+let commit = 'dev';
+try {
+  commit = execSync('git rev-parse --short HEAD').toString().trim();
+} catch {
+  // ignore if git is not available
+}
+const cacheName = `dsmcs-cache-v${pkg.version}-${commit}`;
+
+let sw = readFileSync(join(root, 'service-worker.template.js'), 'utf8');
+sw = sw.replace(/{{CACHE_NAME}}/g, cacheName);
+writeFileSync(join(root, 'service-worker.js'), sw);
+console.log(`service-worker.js generated with CACHE_NAME=${cacheName}`);

--- a/service-worker.template.js
+++ b/service-worker.template.js
@@ -1,4 +1,5 @@
-const CACHE_NAME = 'dsmcs-cache-v1';
+// The build script injects a versioned cache name during `npm run build`
+const CACHE_NAME = '{{CACHE_NAME}}';
 const ASSETS_TO_CACHE = [
   './',
   'index.html',


### PR DESCRIPTION
## Summary
- generate service-worker.js from a template
- add build script injecting a cache version
- ignore generated service worker
- document new `npm run build` command

## Testing
- `npm ci`
- `npm test` *(fails: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68463a7e0b5883218e8762339225994d