### PR TITLE
Add ES module type

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Individual sections are collapsible using the native `<details>`/`<summary>` ele
 Development and the test suite expect **Node.js 20** or newer. You can check your installed version with `node --version`.
 An `.nvmrc` file at the project root pins this version for `nvm` users; run `nvm use` after cloning.
 When installing dependencies, run `npm ci` to guarantee a reproducible environment.
+The Node build scripts use ES module syntax. `package.json` sets `"type": "module"` so Node treats `.js` files as ES modules.
 
 ## Running Tests
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "dark-souls-minimal-cheat-sheet",
   "version": "1.0.0",
   "description": "Dark Souls Minimal Cheat Sheet",
+  "type": "module",
   "repository": "https://github.com/Vesylum/dark-souls-minimal-cheat-sheet",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Summary
- mark package as an ES module
- document ES module usage

## Testing
- `npm run build`
- `npm test` *(fails: qunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68463e3ebf448321bfec49e2175813a6