### PR TITLE
Enable ES modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Before serving, generate the service worker with `npm run build` so the cache na
 Checklist content now lives in `data/playthrough.json`. This file lists each playthrough section and the items within it. The JavaScript fetches this JSON on page load and generates the checklist dynamically.
 Individual sections are collapsible using the native `<details>`/`<summary>` elements with the first section expanded by default.
 
-Development and the test suite expect **Node.js 20** or newer. You can check your installed version with `node --version`.
+Development and the test suite expect **Node.js 20** or newer and use Node's ES module support. The `package.json` file sets `"type": "module"` so Node treats `*.js` files as ES modules. You can check your installed version with `node --version`.
 An `.nvmrc` file at the project root pins this version for `nvm` users; run `nvm use` after cloning.
 When installing dependencies, run `npm ci` to guarantee a reproducible environment.
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Dark Souls Minimal Cheat Sheet",
   "repository": "https://github.com/Vesylum/dark-souls-minimal-cheat-sheet",
+  "type": "module",
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
## Summary
- add `type: module` to package.json
- document ES module usage in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68463d71e37c832193e4abff899065a0