### PR TITLE
Add module type to Node build

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Development and the test suite expect **Node.js 20** or newer. You can check you
 An `.nvmrc` file at the project root pins this version for `nvm` users; run `nvm use` after cloning.
 When installing dependencies, run `npm ci` to guarantee a reproducible environment.
 
+Node scripts use ES module syntax. The `package.json` file sets `"type": "module"`
+so Node treats `.js` files as ES modules.
+
 ## Running Tests
 
 A small QUnit test suite validates the client-side logic. Install dependencies with `npm ci` for reproducible installs and run the tests with:

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "dark-souls-minimal-cheat-sheet",
   "version": "1.0.0",
   "description": "Dark Souls Minimal Cheat Sheet",
+  "type": "module",
   "repository": "https://github.com/Vesylum/dark-souls-minimal-cheat-sheet",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Summary
- specify `type: module` in `package.json`
- document ES module usage in the README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68463decd5c483218f2f9071cbe23ed7