### PR TITLE
Fix duplicate package type

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Dark Souls Minimal Cheat Sheet",
   "type": "module",
   "repository": "https://github.com/Vesylum/dark-souls-minimal-cheat-sheet",
-  "type": "module",
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
## Summary
- remove redundant `type` field in `package.json`

## Testing
- `npm test` *(fails: require is not defined)*
- `npm run lint` *(fails: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68464062995483218dc276be7a485693