### PR TITLE
Use ESM for eslint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,7 @@
-const js = require('@eslint/js');
-const globals = require('globals');
+import js from '@eslint/js';
+import globals from 'globals';
 
-module.exports = [
+export default [
   {
     ignores: [
       'js/bootstrap.min.js',


### PR DESCRIPTION
## Summary
- convert `eslint.config.js` from CommonJS to ESM

## Testing
- `npm run lint`
- `npm test` *(fails: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6846406c29fc832189bdf59c11df8eab