### PR TITLE
Fix typo in help section

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,7 +282,7 @@
 
                 <h3>Do I need to follow the playthrough in this exact order?</h3>
                 <p>
-                    Dark Souls is not a liner game and has multiple ways of progressing. This is generally the way I
+                    Dark Souls is not a linear game and has multiple ways of progressing. This is generally the way I
                     like to play through the game, so feel free to follow it if you like or mix it up. You can always
                     jump back and forth and check things off in a different order.
                 </p>


### PR DESCRIPTION
## Summary
- fix a small typo in the Help section

## Testing
- `npm ci`
- `npm test` *(fails: ReferenceError: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68464076711c8321889d1de8663a66b2