### PR TITLE
Add file-based progress import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ The tests execute under Node.js using jsdom to simulate a browser environment.
 ## Exporting and Importing Progress
 
 The site stores your checklist data in the browser. Click **Export Progress** to
-copy it as a JSON string. Use **Import Progress** to paste that string into
-another browser or after clearing your storage to restore your progress.
+download it as a JSON file. Use **Import Progress** and choose that file to
+restore your progress after clearing your storage or on another browser.
 
 ## Service Worker Cache
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,10 @@
                         <button class="btn" type="button" id="profileEdit">Edit</button>
                         <button class="btn btn-danger" type="button" id="progressReset">Reset Progress</button>
                         <button class="btn" type="button" id="progressExport">Export Progress</button>
+                        <a class="btn" id="progressDownload" download="progress.json" style="display:none;">Download</a>
                         <button class="btn" type="button" id="progressImport">Import Progress</button>
+                        <input type="file" id="progressFile" accept="application/json" style="display:none;" />
+                        <span id="importError" class="text-danger"></span>
                    </div>
                 </div>
             </div>

--- a/js/main.js
+++ b/js/main.js
@@ -90,16 +90,42 @@
 
         $('#progressExport').click(function() {
             const data = serializeProfiles();
-            window.prompt('Copy your progress JSON', data);
+            const blob = new Blob([data], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const $link = $('#progressDownload');
+            if ($link.length) {
+                $link.attr('href', url);
+                $link[0].click();
+                setTimeout(() => URL.revokeObjectURL(url));
+            }
         });
 
         $('#progressImport').click(function() {
-            const data = window.prompt('Paste progress JSON to import');
-            if (data) {
-                if (!restoreProfiles(data)) {
-                    alert('Invalid progress data');
-                }
+            const $file = $('#progressFile');
+            if ($file.length) {
+                $file.trigger('click');
             }
+        });
+
+        $('#progressFile').change(function() {
+            const file = this.files[0];
+            if (!file) {
+                return;
+            }
+            const reader = new FileReader();
+            reader.onload = function(e) {
+                const ok = restoreProfiles(e.target.result);
+                if (!ok) {
+                    $('#importError').text('Invalid progress data');
+                } else {
+                    $('#importError').text('');
+                }
+            };
+            reader.onerror = function() {
+                $('#importError').text('Unable to read file');
+            };
+            reader.readAsText(file);
+            $(this).val('');
         });
 
         $('#profileModalAdd').click(function(event) {

--- a/tests/exportImport.test.cjs
+++ b/tests/exportImport.test.cjs
@@ -13,7 +13,11 @@ QUnit.module('export/import progress', hooks => {
       '<select id="profiles"></select>' +
       '<input type="checkbox" id="foo_1_1">' +
       '<input type="checkbox" id="foo_1_2">' +
+      '<button id="progressExport"></button>' +
+      '<a id="progressDownload"></a>' +
       '<button id="progressImport"></button>' +
+      '<input id="progressFile" type="file">' +
+      '<span id="importError"></span>' +
       '</body></html>', { url: 'http://localhost' });
     const { window } = dom;
     global.window = window;
@@ -46,8 +50,6 @@ QUnit.module('export/import progress', hooks => {
     delete global.window;
     delete global.document;
     delete global.$;
-    delete global.alert;
-    delete global.prompt;
   });
 
   QUnit.test('serializeProfiles returns stored JSON', assert => {
@@ -77,19 +79,51 @@ QUnit.module('export/import progress', hooks => {
     assert.strictEqual(document.getElementById('profiles').value, 'Profile1', 'profile select unchanged');
   });
 
-  QUnit.test('restoreProfiles rejects bad JSON and import button alerts', assert => {
+  QUnit.test('restoreProfiles rejects bad JSON and import button shows error', assert => {
     const before = JSON.parse(window.localStorage.getItem('profiles'));
     const ok = window.restoreProfiles('bad json');
     assert.notOk(ok, 'restore failed');
     const after = JSON.parse(window.localStorage.getItem('profiles'));
     assert.deepEqual(after, before, 'localStorage unchanged');
 
-    let alertCalled = false;
-    window.prompt = global.prompt = () => 'bad json';
-    window.alert = global.alert = () => { alertCalled = true; };
+    class FR {
+      readAsText() { this.onload({ target: { result: 'bad json' } }); }
+    }
+    window.FileReader = FR;
 
-    $('#progressImport').trigger('click');
-    assert.ok(alertCalled, 'alert shown');
+    $('#progressFile').trigger('change', { target: { files: [new Blob()] } });
+    assert.strictEqual(document.getElementById('importError').textContent, 'Invalid progress data', 'error shown');
+    delete window.FileReader;
+  });
+
+  QUnit.test('export generates downloadable blob', async assert => {
+    let blobArg;
+    const orig = window.URL.createObjectURL;
+    window.URL.createObjectURL = b => { blobArg = b; return 'blob:url'; };
+    const link = document.getElementById('progressDownload');
+    let clicked = false;
+    link.click = () => { clicked = true; };
+
+    $('#progressExport').trigger('click');
+
+    assert.ok(clicked, 'download triggered');
+    const text = await blobArg.text();
+    assert.strictEqual(text, JSON.stringify(store1), 'blob content');
+    window.URL.createObjectURL = orig;
+  });
+
+  QUnit.test('file import loads progress', assert => {
+    class FR {
+      readAsText() { this.onload({ target: { result: JSON.stringify(store2) } }); }
+    }
+    window.FileReader = FR;
+
+    $('#progressFile').trigger('change', { target: { files: [new Blob()] } });
+
+    const saved = JSON.parse(window.localStorage.getItem('profiles'));
+    assert.deepEqual(saved, store2, 'localStorage updated');
+    assert.strictEqual(document.getElementById('profiles').value, 'Profile2', 'profile select updated');
+    delete window.FileReader;
   });
 
   QUnit.test('restoreProfiles rejects invalid profile structure', assert => {


### PR DESCRIPTION
## Summary
- add progress download link and import file input
- generate a blob for exporting progress
- load progress from a selected file and show an error if parsing fails
- document the new workflow for exporting and importing
- update tests for the file-based workflow

## Testing
- `npm run lint`
- `npm test` *(fails: progress clearing assertions)*

------
https://chatgpt.com/codex/tasks/task_e_684646e5b5bc8321bc0207b76573b841