### PR TITLE
Implement dark mode and theme toggle

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -9,6 +9,57 @@ details summary {
     margin-bottom: 0.5em;
 }
 
+/* Allow user agent to adjust form controls for dark mode */
+:root {
+    color-scheme: light dark;
+}
+
+@media (prefers-color-scheme: dark) {
+    body:not(.light-theme) {
+        background-color: #121212;
+        color: #e0e0e0;
+    }
+    body:not(.light-theme) a {
+        color: #8ab4f8;
+    }
+    body:not(.light-theme) .navbar,
+    body:not(.light-theme) .navbar-inner {
+        background-color: #333;
+        color: #e0e0e0;
+    }
+    body:not(.light-theme) .table-striped tbody tr:nth-child(odd) td,
+    body:not(.light-theme) .table-striped tbody tr:nth-child(odd) th {
+        background-color: #1e1e1e;
+    }
+    body:not(.light-theme) input[type="checkbox"] {
+        accent-color: #0d6efd;
+    }
+    body:not(.light-theme) .in_progress { color: #ffb74d; }
+    body:not(.light-theme) .done { color: #66bb6a; }
+}
+
+body.dark-theme {
+    background-color: #121212;
+    color: #e0e0e0;
+}
+body.dark-theme a {
+    color: #8ab4f8;
+}
+body.dark-theme .navbar,
+body.dark-theme .navbar-inner {
+    background-color: #333;
+    color: #e0e0e0;
+}
+body.dark-theme .table-striped tbody tr:nth-child(odd) td,
+body.dark-theme .table-striped tbody tr:nth-child(odd) th {
+    background-color: #1e1e1e;
+}
+body.dark-theme input[type="checkbox"] {
+    accent-color: #0d6efd;
+}
+body.dark-theme .in_progress { color: #ffb74d; }
+body.dark-theme .done { color: #66bb6a; }
+
 @media print {
     body { color: #000; }
     .navbar, #intro, input[type="checkbox"] { display: none; }

--- a/index.html
+++ b/index.html
@@ -57,6 +57,11 @@
                         <button class="btn btn-danger" type="button" id="progressReset">Reset Progress</button>
                         <button class="btn" type="button" id="progressExport">Export Progress</button>
                         <button class="btn" type="button" id="progressImport">Import Progress</button>
+                        <select id="themeSelect" style="margin-left: 5px;" title="Theme">
+                            <option value="system">System</option>
+                            <option value="light">Light</option>
+                            <option value="dark">Dark</option>
+                        </select>
                    </div>
                 </div>
             </div>

--- a/js/main.js
+++ b/js/main.js
@@ -34,8 +34,26 @@
     }
     let profiles = storageGet(profilesKey, defaultProfiles);
 
+    const themeKey = 'theme';
+
+    function applyTheme() {
+        const pref = window.localStorage.getItem(themeKey) || 'system';
+        const body = document.body;
+        if (pref === 'dark' || pref === 'light') {
+            body.classList.remove('dark-theme', 'light-theme');
+            body.classList.add(pref + '-theme');
+        } else {
+            body.classList.remove('dark-theme', 'light-theme');
+        }
+        const select = document.getElementById('themeSelect');
+        if (select) {
+            select.value = pref;
+        }
+    }
+
     jQuery(document).ready(function($) {
 
+        applyTheme();
         loadPlaythrough();
         loadChecklists();
         populateProfiles();
@@ -58,6 +76,12 @@
             profiles.current = $select.val();
             storageSet(profilesKey, profiles);
             populateChecklists();
+        });
+
+        $('#themeSelect').change(function() {
+            const val = $(this).val();
+            window.localStorage.setItem(themeKey, val);
+            applyTheme();
         });
 
         $('#profileAdd').click(function() {
@@ -451,6 +475,7 @@
         window.populateChecklists = populateChecklists;
         window.canDelete = canDelete;
         window.getFirstProfile = getFirstProfile;
+        window.applyTheme = applyTheme;
     }
 
 })( jQuery );


### PR DESCRIPTION
## Summary
- add dark-mode CSS with prefers-color-scheme and manual class
- provide theme override selector in the navbar
- apply theme at startup and save preference

## Testing
- `npm ci`
- `npm test` *(fails: window functions not found)*

------
https://chatgpt.com/codex/tasks/task_e_684646f8c14483218111b4e889f82a13