### PR TITLE
Initialize jQuery in tests with window

### DIFF
--- a/tests/addCheckbox.test.cjs
+++ b/tests/addCheckbox.test.cjs
@@ -14,7 +14,7 @@ QUnit.module('addCheckbox', hooks => {
     global.document = window.document;
 
     delete require.cache[require.resolve('jquery')];
-    $ = require('jquery');
+    $ = require('jquery')(window);
     global.$ = global.jQuery = window.$ = $;
 
     $.getJSON = (_url, cb) => {

--- a/tests/calculateTotals.test.cjs
+++ b/tests/calculateTotals.test.cjs
@@ -11,7 +11,7 @@ QUnit.module('calculateTotals', hooks => {
     global.document = window.document;
 
     delete require.cache[require.resolve('jquery')];
-    $ = require('jquery');
+    $ = require('jquery')(window);
     global.$ = global.jQuery = window.$ = $;
 
     $.getJSON = (_url, cb) => { setTimeout(() => cb({}), 0); };

--- a/tests/defaultProfilesClone.test.cjs
+++ b/tests/defaultProfilesClone.test.cjs
@@ -13,7 +13,7 @@ QUnit.module('defaultProfiles clone', hooks => {
     global.document = window.document;
 
     delete require.cache[require.resolve('jquery')];
-    $ = require('jquery');
+    $ = require('jquery')(window);
     global.$ = global.jQuery = window.$ = $;
 
     $.getJSON = (_url, cb) => { setTimeout(() => cb({}), 0); };

--- a/tests/exportImport.test.cjs
+++ b/tests/exportImport.test.cjs
@@ -24,7 +24,7 @@ QUnit.module('export/import progress', hooks => {
     global.document = window.document;
 
     delete require.cache[require.resolve('jquery')];
-    $ = require('jquery');
+    $ = require('jquery')(window);
     global.$ = global.jQuery = window.$ = $;
 
     $.getJSON = (_url, cb) => { setTimeout(() => cb({}), 0); };

--- a/tests/loadChecklists.test.cjs
+++ b/tests/loadChecklists.test.cjs
@@ -15,7 +15,7 @@ QUnit.module('loadChecklists', hooks => {
     global.document = window.document;
 
     delete require.cache[require.resolve('jquery')];
-    $ = require('jquery');
+    $ = require('jquery')(window);
     global.$ = global.jQuery = window.$ = $;
 
     $.getJSON = (url, cb) => {

--- a/tests/loadChecklistsFail.test.cjs
+++ b/tests/loadChecklistsFail.test.cjs
@@ -14,7 +14,7 @@ QUnit.module('loadChecklists failure', hooks => {
     global.document = window.document;
 
     delete require.cache[require.resolve('jquery')];
-    $ = require('jquery');
+    $ = require('jquery')(window);
     global.$ = global.jQuery = window.$ = $;
 
     $.getJSON = () => ({

--- a/tests/loadPlaythrough.test.cjs
+++ b/tests/loadPlaythrough.test.cjs
@@ -15,7 +15,7 @@ QUnit.module('loadPlaythrough', hooks => {
     global.document = window.document;
 
     delete require.cache[require.resolve('jquery')];
-    $ = require('jquery');
+    $ = require('jquery')(window);
     global.$ = global.jQuery = window.$ = $;
 
     $.getJSON = (url, cb) => {

--- a/tests/loadPlaythroughFail.test.cjs
+++ b/tests/loadPlaythroughFail.test.cjs
@@ -14,7 +14,7 @@ QUnit.module('loadPlaythrough failure', hooks => {
     global.document = window.document;
 
     delete require.cache[require.resolve('jquery')];
-    $ = require('jquery');
+    $ = require('jquery')(window);
     global.$ = global.jQuery = window.$ = $;
 
     $.getJSON = () => ({

--- a/tests/populateFunctions.test.cjs
+++ b/tests/populateFunctions.test.cjs
@@ -16,7 +16,7 @@ QUnit.module('populate functions', hooks => {
     global.document = window.document;
 
     delete require.cache[require.resolve('jquery')];
-    $ = require('jquery');
+    $ = require('jquery')(window);
     global.$ = global.jQuery = window.$ = $;
 
     $.getJSON = (_url, cb) => { setTimeout(() => cb({}), 0); };

--- a/tests/profileAddDuplicate.test.cjs
+++ b/tests/profileAddDuplicate.test.cjs
@@ -18,7 +18,7 @@ QUnit.module('profile add duplicate', hooks => {
     global.document = window.document;
 
     delete require.cache[require.resolve('jquery')];
-    $ = require('jquery');
+    $ = require('jquery')(window);
     global.$ = global.jQuery = window.$ = $;
     $.getJSON = (_url, cb) => { setTimeout(() => cb({}), 0); };
     $.fn.modal = () => {};

--- a/tests/profileRename.test.cjs
+++ b/tests/profileRename.test.cjs
@@ -18,7 +18,7 @@ QUnit.module('profile rename', hooks => {
     global.document = window.document;
 
     delete require.cache[require.resolve('jquery')];
-    $ = require('jquery');
+    $ = require('jquery')(window);
     global.$ = global.jQuery = window.$ = $;
     $.getJSON = (_url, cb) => { setTimeout(() => cb({}), 0); };
     $.fn.modal = () => {};

--- a/tests/profileUtils.test.cjs
+++ b/tests/profileUtils.test.cjs
@@ -10,7 +10,7 @@ async function setup(store) {
   global.document = window.document;
 
   delete require.cache[require.resolve('jquery')];
-  $ = require('jquery');
+  $ = require('jquery')(window);
   global.$ = global.jQuery = window.$ = $;
 
   $.getJSON = (_url, cb) => { setTimeout(() => cb({}), 0); };

--- a/tests/resetProgress.test.cjs
+++ b/tests/resetProgress.test.cjs
@@ -14,7 +14,7 @@ QUnit.module('resetProgress', hooks => {
     global.document = window.document;
 
     delete require.cache[require.resolve('jquery')];
-    $ = require('jquery');
+    $ = require('jquery')(window);
     global.$ = global.jQuery = window.$ = $;
 
     $.getJSON = (_url, cb) => { setTimeout(() => cb({}), 0); };


### PR DESCRIPTION
## Summary
- bind jQuery to the provided JSDOM window in all tests

## Testing
- `npm test` *(fails: jQuery is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6846524299548321a35e0b4e94b6b4e1