### PR TITLE
Fix jQuery fallback timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,6 @@
         if (!window.jQuery) {
             var script = document.createElement('script');
             script.src = 'js/jquery-3.7.1.min.js';
-            script.defer = true;
             document.head.appendChild(script);
         }
     </script>

--- a/tests/jqueryFallback.test.cjs
+++ b/tests/jqueryFallback.test.cjs
@@ -17,7 +17,6 @@ QUnit.test('main.js runs with local jQuery when CDN fails', assert => {
     if (!window.jQuery) {
       var script = document.createElement('script');
       script.src = 'js/jquery-3.7.1.min.js';
-      script.defer = true;
       document.head.appendChild(script);
     }
   `;


### PR DESCRIPTION
## Summary
- ensure fallback jQuery loads immediately instead of deferred
- adjust fallback test to match behaviour

## Testing
- `npm test` *(fails: Cannot read properties of null)*
- `npx qunit tests/jqueryFallback.test.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68465248e0c483219c775c537aef9a5b