### PR TITLE
Improve filterItems search logic

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -478,8 +478,19 @@
     function filterItems(query, containerSelector) {
         const q = query.toLowerCase();
         $(containerSelector).find('li[data-id]').each(function() {
-            const text = $(this).text().toLowerCase();
-            $(this).toggle(text.indexOf(q) !== -1);
+            const $li = $(this);
+            const ownText = $li.clone().children('ul').remove().end().text().toLowerCase();
+            let match = ownText.indexOf(q) !== -1;
+            if (!match) {
+                $li.find('li[data-id]').each(function() {
+                    const subText = $(this).clone().children('ul').remove().end().text().toLowerCase();
+                    if (subText.indexOf(q) !== -1) {
+                        match = true;
+                        return false; // break loop
+                    }
+                });
+            }
+            $li.toggle(match);
         });
     }
 
@@ -491,6 +502,7 @@
         window.restoreProfiles = restoreProfiles;
         window.populateProfiles = populateProfiles;
         window.populateChecklists = populateChecklists;
+        window.filterItems = filterItems;
         window.canDelete = canDelete;
         window.getFirstProfile = getFirstProfile;
     }

--- a/tests/filterItems.test.cjs
+++ b/tests/filterItems.test.cjs
@@ -1,0 +1,49 @@
+const { JSDOM } = require('jsdom');
+const QUnit = require('qunit');
+
+let $;
+
+QUnit.module('filterItems', hooks => {
+  hooks.beforeEach(() => {
+    const dom = new JSDOM('<!doctype html><html><body>' +
+      '<ul id="list">' +
+        '<li data-id="p">Parent<ul>' +
+          '<li data-id="c1">Alpha</li>' +
+          '<li data-id="c2">Beta</li>' +
+        '</ul></li>' +
+      '</ul>' +
+      '</body></html>', { url: 'http://localhost' });
+    const { window } = dom;
+    global.window = window;
+    global.document = window.document;
+
+    delete require.cache[require.resolve('jquery')];
+    $ = require('jquery');
+    global.$ = global.jQuery = window.$ = $;
+
+    $.getJSON = (_url, cb) => { setTimeout(() => cb({}), 0); };
+
+    delete require.cache[require.resolve('../js/main.js')];
+    require('../js/main.js');
+    document.dispatchEvent(new window.Event('DOMContentLoaded'));
+    return new Promise(r => setTimeout(r, 50));
+  });
+
+  hooks.afterEach(() => {
+    delete global.$;
+    delete global.jQuery;
+    delete window.$;
+    delete global.window;
+    delete global.document;
+  });
+
+  QUnit.test('li remains visible when descendant matches', assert => {
+    window.filterItems('Alpha', '#list');
+    const parent = document.querySelector('li[data-id="p"]');
+    const child1 = document.querySelector('li[data-id="c1"]');
+    const child2 = document.querySelector('li[data-id="c2"]');
+    assert.strictEqual(parent.style.display, '', 'parent visible');
+    assert.strictEqual(child1.style.display, '', 'matching child visible');
+    assert.strictEqual(child2.style.display, 'none', 'non matching child hidden');
+  });
+});


### PR DESCRIPTION
## Summary
- search each `<li>` and descendants for text when filtering
- expose `filterItems` for tests
- add QUnit test covering child match visibility

## Testing
- `npm test` *(fails: Cannot read properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68465253fe1c8321a2ee68a688a2aae6