### PR TITLE
Add defer to jQuery fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         if (!window.jQuery) {
             var script = document.createElement('script');
             script.src = 'js/jquery-3.7.1.min.js';
+            script.defer = true;
             document.head.appendChild(script);
         }
     </script>

--- a/tests/jqueryFallback.test.cjs
+++ b/tests/jqueryFallback.test.cjs
@@ -17,6 +17,7 @@ QUnit.test('main.js runs with local jQuery when CDN fails', assert => {
     if (!window.jQuery) {
       var script = document.createElement('script');
       script.src = 'js/jquery-3.7.1.min.js';
+      script.defer = true;
       document.head.appendChild(script);
     }
   `;


### PR DESCRIPTION
## Summary
- load jQuery fallback with `defer` in index.html
- include `.defer = true` in jqueryFallback test snippet

## Testing
- `npm test` *(fails: Unexpected module status 5)*

------
https://chatgpt.com/codex/tasks/task_e_684663a48e1c832180dbbf9609691997