### PR TITLE
Add delay before revoking export blob

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -104,7 +104,7 @@
             if ($link.length) {
                 $link.attr('href', url);
                 $link[0].click();
-                setTimeout(() => URL.revokeObjectURL(url));
+                setTimeout(() => URL.revokeObjectURL(url), 1000);
             }
         });
 


### PR DESCRIPTION
## Summary
- ensure exported Blob URL is revoked after a short delay

## Testing
- `npm test` *(fails: $ is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_684666125d1c8321a5d5002f7ede0cfb