### PR TITLE
Fix profile utils

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -341,17 +341,11 @@
     }
 
     function canDelete() {
-        let count = 0;
-        $.each(profiles[profilesKey], function(index, value) {
-            count++;
-        });
-        return (count > 1);
+        return Object.keys(profiles[profilesKey]).length > 1;
     }
 
     function getFirstProfile() {
-        for (const profile in profiles[profilesKey]) {
-            return profile;
-        }
+        return Object.keys(profiles[profilesKey])[0];
     }
 
     function loadPlaythrough() {


### PR DESCRIPTION
## Summary
- fix `canDelete()` to check profile count using `Object.keys`
- simplify `getFirstProfile()`

## Testing
- `npm test` *(fails: Unexpected module status 5)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6846661a4c0483218e35293159d07be1