### PR TITLE
Fix dynamic import usage in tests

### DIFF
--- a/tests/addCheckbox.test.cjs
+++ b/tests/addCheckbox.test.cjs
@@ -4,7 +4,7 @@ const QUnit = require('qunit');
 let $;
 
 QUnit.module('addCheckbox', hooks => {
-  hooks.beforeEach(() => {
+  hooks.beforeEach(async () => {
     const dom = new JSDOM('<!doctype html><html><body>' +
       '<div id="playthrough_sections"></div>' +
       '<ul id="playthrough_nav"></ul>' +
@@ -33,8 +33,7 @@ QUnit.module('addCheckbox', hooks => {
       ]), 0);
     };
 
-    delete require.cache[require.resolve('../js/main.js')];
-    require('../js/main.js');
+    await import('../js/main.js');
     document.dispatchEvent(new window.Event('DOMContentLoaded'));
     return new Promise(r => setTimeout(r, 50));
   });

--- a/tests/calculateTotals.test.cjs
+++ b/tests/calculateTotals.test.cjs
@@ -4,7 +4,7 @@ const QUnit = require('qunit');
 let $;
 
 QUnit.module('calculateTotals', hooks => {
-  hooks.beforeEach(() => {
+  hooks.beforeEach(async () => {
     const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost' });
     const { window } = dom;
     global.window = window;
@@ -17,8 +17,7 @@ QUnit.module('calculateTotals', hooks => {
     $.getJSON = (_url, cb) => { setTimeout(() => cb({}), 0); };
 
 
-    delete require.cache[require.resolve('../js/main.js')];
-    require('../js/main.js');
+    await import('../js/main.js');
     document.dispatchEvent(new window.Event('DOMContentLoaded'));
     return new Promise(r => setTimeout(r, 50));
   });

--- a/tests/defaultProfilesClone.test.cjs
+++ b/tests/defaultProfilesClone.test.cjs
@@ -4,7 +4,7 @@ const QUnit = require('qunit');
 let $;
 
 QUnit.module('defaultProfiles clone', hooks => {
-  hooks.beforeEach(() => {
+  hooks.beforeEach(async () => {
     const dom = new JSDOM('<!doctype html><html><body>' +
       '<input type="checkbox" id="foo_1_1">' +
       '</body></html>', { url: 'http://localhost' });
@@ -18,8 +18,7 @@ QUnit.module('defaultProfiles clone', hooks => {
 
     $.getJSON = (_url, cb) => { setTimeout(() => cb({}), 0); };
 
-    delete require.cache[require.resolve('../js/main.js')];
-    require('../js/main.js');
+    await import('../js/main.js');
     document.dispatchEvent(new window.Event('DOMContentLoaded'));
     return new Promise(r => setTimeout(r, 50));
   });

--- a/tests/exportImport.test.cjs
+++ b/tests/exportImport.test.cjs
@@ -6,7 +6,7 @@ let store1;
 let store2;
 
 QUnit.module('export/import progress', hooks => {
-  hooks.beforeEach(() => {
+  hooks.beforeEach(async () => {
     const dom = new JSDOM('<!doctype html><html><body>' +
       '<div id="playthrough_sections"></div>' +
       '<ul id="playthrough_nav"></ul>' +
@@ -40,8 +40,7 @@ QUnit.module('export/import progress', hooks => {
 
     window.localStorage.setItem('profiles', JSON.stringify(store1));
 
-    delete require.cache[require.resolve('../js/main.js')];
-    require('../js/main.js');
+    await import('../js/main.js');
     document.dispatchEvent(new window.Event('DOMContentLoaded'));
     return new Promise(r => setTimeout(r, 50));
   });

--- a/tests/filterItems.test.cjs
+++ b/tests/filterItems.test.cjs
@@ -4,7 +4,7 @@ const QUnit = require('qunit');
 let $;
 
 QUnit.module('filterItems', hooks => {
-  hooks.beforeEach(() => {
+  hooks.beforeEach(async () => {
     const dom = new JSDOM('<!doctype html><html><body>' +
       '<ul id="list">' +
         '<li data-id="p">Parent<ul>' +
@@ -23,8 +23,7 @@ QUnit.module('filterItems', hooks => {
 
     $.getJSON = (_url, cb) => { setTimeout(() => cb({}), 0); };
 
-    delete require.cache[require.resolve('../js/main.js')];
-    require('../js/main.js');
+    await import('../js/main.js');
     document.dispatchEvent(new window.Event('DOMContentLoaded'));
     return new Promise(r => setTimeout(r, 50));
   });

--- a/tests/loadChecklists.test.cjs
+++ b/tests/loadChecklists.test.cjs
@@ -4,7 +4,7 @@ const QUnit = require('qunit');
 let $;
 
 QUnit.module('loadChecklists', hooks => {
-  hooks.beforeEach(() => {
+  hooks.beforeEach(async () => {
     const dom = new JSDOM('<!doctype html><html><body>' +
       '<div id="playthrough_sections"></div>' +
       '<ul id="playthrough_nav"></ul>' +
@@ -32,8 +32,7 @@ QUnit.module('loadChecklists', hooks => {
       }
     };
 
-    delete require.cache[require.resolve('../js/main.js')];
-    require('../js/main.js');
+    await import('../js/main.js');
     document.dispatchEvent(new window.Event('DOMContentLoaded'));
     return new Promise(r => setTimeout(r, 50));
   });

--- a/tests/loadChecklistsFail.test.cjs
+++ b/tests/loadChecklistsFail.test.cjs
@@ -5,7 +5,7 @@ let $;
 let alertCalled;
 
 QUnit.module('loadChecklists failure', hooks => {
-  hooks.beforeEach(() => {
+  hooks.beforeEach(async () => {
     const dom = new JSDOM('<!doctype html><html><body>' +
       '<div id="checklists"></div>' +
       '</body></html>', { url: 'http://localhost' });
@@ -25,8 +25,7 @@ QUnit.module('loadChecklists failure', hooks => {
     global.alert = () => { alertCalled = true; };
     alert = global.alert;
 
-    delete require.cache[require.resolve('../js/main.js')];
-    require('../js/main.js');
+    await import('../js/main.js');
     document.dispatchEvent(new window.Event('DOMContentLoaded'));
     return new Promise(r => setTimeout(r, 50));
   });

--- a/tests/loadPlaythrough.test.cjs
+++ b/tests/loadPlaythrough.test.cjs
@@ -4,7 +4,7 @@ const QUnit = require('qunit');
 let $;
 
 QUnit.module('loadPlaythrough', hooks => {
-  hooks.beforeEach(() => {
+  hooks.beforeEach(async () => {
     const dom = new JSDOM('<!doctype html><html><body>' +
       '<div id="playthrough_sections"></div>' +
       '<ul id="playthrough_nav"></ul>' +
@@ -32,8 +32,7 @@ QUnit.module('loadPlaythrough', hooks => {
       }
     };
 
-    delete require.cache[require.resolve('../js/main.js')];
-    require('../js/main.js');
+    await import('../js/main.js');
     document.dispatchEvent(new window.Event('DOMContentLoaded'));
     return new Promise(r => setTimeout(r, 50));
   });

--- a/tests/loadPlaythroughFail.test.cjs
+++ b/tests/loadPlaythroughFail.test.cjs
@@ -5,7 +5,7 @@ let $;
 let alertCalled;
 
 QUnit.module('loadPlaythrough failure', hooks => {
-  hooks.beforeEach(() => {
+  hooks.beforeEach(async () => {
     const dom = new JSDOM('<!doctype html><html><body>' +
       '<div id="playthrough_sections"></div>' +
       '</body></html>', { url: 'http://localhost' });
@@ -25,8 +25,7 @@ QUnit.module('loadPlaythrough failure', hooks => {
     global.alert = () => { alertCalled = true; };
     alert = global.alert;
 
-    delete require.cache[require.resolve('../js/main.js')];
-    require('../js/main.js');
+    await import('../js/main.js');
     document.dispatchEvent(new window.Event('DOMContentLoaded'));
     return new Promise(r => setTimeout(r, 50));
   });

--- a/tests/populateFunctions.test.cjs
+++ b/tests/populateFunctions.test.cjs
@@ -5,7 +5,7 @@ let $;
 let store;
 
 QUnit.module('populate functions', hooks => {
-  hooks.beforeEach(() => {
+  hooks.beforeEach(async () => {
     const dom = new JSDOM('<!doctype html><html><body>\n'
       + '<select id="profiles"></select>\n'
       + '<input type="checkbox" id="foo_1_1">\n'
@@ -31,8 +31,7 @@ QUnit.module('populate functions', hooks => {
 
     window.localStorage.setItem('profiles', JSON.stringify(store));
 
-    delete require.cache[require.resolve('../js/main.js')];
-    require('../js/main.js');
+    await import('../js/main.js');
     document.dispatchEvent(new window.Event('DOMContentLoaded'));
     return new Promise(r => setTimeout(r, 50));
   });

--- a/tests/profileAddDuplicate.test.cjs
+++ b/tests/profileAddDuplicate.test.cjs
@@ -6,7 +6,7 @@ let store;
 let alertCalled;
 
 QUnit.module('profile add duplicate', hooks => {
-  hooks.beforeEach(() => {
+  hooks.beforeEach(async () => {
     const dom = new JSDOM('<!doctype html><html><body>\n' +
       '<input id="profileModalName">\n' +
       '<div id="profileModal"></div>\n' +
@@ -35,8 +35,7 @@ QUnit.module('profile add duplicate', hooks => {
     global.alert = () => { alertCalled = true; };
     alert = global.alert; // expose
 
-    delete require.cache[require.resolve('../js/main.js')];
-    require('../js/main.js');
+    await import('../js/main.js');
     document.dispatchEvent(new window.Event('DOMContentLoaded'));
     return new Promise(r => setTimeout(r, 50));
   });

--- a/tests/profileRename.test.cjs
+++ b/tests/profileRename.test.cjs
@@ -6,7 +6,7 @@ let store;
 let alertCalled;
 
 QUnit.module('profile rename', hooks => {
-  hooks.beforeEach(() => {
+  hooks.beforeEach(async () => {
     const dom = new JSDOM('<!doctype html><html><body>\n'
       + '<input id="profileModalName">\n'
       + '<div id="profileModal"></div>\n'
@@ -35,8 +35,7 @@ QUnit.module('profile rename', hooks => {
     global.alert = () => { alertCalled = true; };
     alert = global.alert; // expose as global variable for strict mode
 
-    delete require.cache[require.resolve('../js/main.js')];
-    require('../js/main.js');
+    await import('../js/main.js');
     document.dispatchEvent(new window.Event('DOMContentLoaded'));
     return new Promise(r => setTimeout(r, 50));
   });

--- a/tests/profileUtils.test.cjs
+++ b/tests/profileUtils.test.cjs
@@ -17,8 +17,7 @@ async function setup(store) {
 
   window.localStorage.setItem('profiles', JSON.stringify(store));
 
-  delete require.cache[require.resolve('../js/main.js')];
-  require('../js/main.js');
+  await import('../js/main.js');
     document.dispatchEvent(new window.Event('DOMContentLoaded'));
   await new Promise(r => setTimeout(r, 50));
 }

--- a/tests/resetProgress.test.cjs
+++ b/tests/resetProgress.test.cjs
@@ -5,7 +5,7 @@ let $;
 let deleted;
 
 QUnit.module('resetProgress', hooks => {
-  hooks.beforeEach(() => {
+  hooks.beforeEach(async () => {
     const dom = new JSDOM('<!doctype html><html><body>'
       + '<button id="progressReset"></button>'
       + '</body></html>', { url: 'http://localhost' });
@@ -33,8 +33,7 @@ QUnit.module('resetProgress', hooks => {
     ls.__proto__.removeItem = function(key) { deleted = true; origRemove.call(this, key); };
     ls.setItem('profiles', JSON.stringify(initialStore));
 
-    delete require.cache[require.resolve('../js/main.js')];
-    require('../js/main.js');
+    await import('../js/main.js');
     document.dispatchEvent(new window.Event('DOMContentLoaded'));
     return new Promise(r => setTimeout(r, 50));
   });


### PR DESCRIPTION
## Summary
- use `await import` in test setup instead of clearing the cache and requiring
- mark each `beforeEach` hook async

## Testing
- `npm test` *(fails: jQuery is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68466635969c8321b3e14e3bc3b05e49