### PR TITLE
Use import map for jquery

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,20 +13,19 @@
     <!--[if lt IE 9]>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
-    <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-2ct7Gh6WijC1ga8zmnjHHirFeB8WYm1E9JGHPa9yK6M=" crossorigin="anonymous"></script>
-    <script>
-        if (!window.jQuery) {
-            var script = document.createElement('script');
-            script.src = 'js/jquery-3.7.1.min.js';
-            script.defer = true;
-            document.head.appendChild(script);
+    <script type="importmap">
+        {
+            "imports": {
+                "jquery": "./js/jquery-3.7.1.min.js"
+            }
         }
     </script>
+    <script src="js/jquery-3.7.1.min.js"></script>
     <script type="text/javascript">
         var profilesKey = 'profiles';
     </script>
     <script defer src="js/bootstrap.min.js"></script>
-    <script defer src="js/main.js"></script>
+    <script type="module" src="js/main.js"></script>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-9QN8C279EF"></script>
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,4 @@
+import jQuery from 'jquery';
 (function($) {
     "use strict";
 
@@ -34,7 +35,7 @@
     }
     let profiles = storageGet(profilesKey, defaultProfiles);
 
-    jQuery(document).ready(function($) {
+    $(document).ready(function($) {
 
         loadPlaythrough();
         loadChecklists();
@@ -501,4 +502,4 @@
         window.getFirstProfile = getFirstProfile;
     }
 
-})( jQuery );
+})(jQuery);

--- a/tests/jqueryFallback.test.cjs
+++ b/tests/jqueryFallback.test.cjs
@@ -1,11 +1,10 @@
-const fs = require('fs');
 const { JSDOM } = require('jsdom');
 const jQueryFactory = require('jquery');
 const QUnit = require('qunit');
 
 QUnit.module('jQuery fallback');
 
-QUnit.test('main.js runs with local jQuery when CDN fails', assert => {
+QUnit.test('main.js runs with local jQuery when CDN fails', async assert => {
   const dom = new JSDOM('<!doctype html><html><body></body></html>', {
     runScripts: 'outside-only',
     url: 'http://localhost'
@@ -35,8 +34,7 @@ QUnit.test('main.js runs with local jQuery when CDN fails', assert => {
     fail: cb => { setTimeout(cb, 0); }
   });
 
-  const main = fs.readFileSync('js/main.js', 'utf8');
-  window.eval(main);
+  await import('../js/main.js');
 
   assert.ok(window.jQuery, 'jQuery loaded');
   assert.strictEqual(typeof window.calculateTotals, 'function', 'main.js executed');


### PR DESCRIPTION
## Summary
- add an import map for jquery and load it locally
- load main.js as an ES module
- update jquery fallback test to use dynamic import

## Testing
- `npm test` *(fails: alert is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68468aad8f64832195bde5873aca6c89