### PR TITLE
Refactor fallback test to use dynamic import

### DIFF
--- a/tests/jqueryFallback.test.cjs
+++ b/tests/jqueryFallback.test.cjs
@@ -1,11 +1,9 @@
-const fs = require('fs');
 const { JSDOM } = require('jsdom');
-const jQueryFactory = require('jquery');
 const QUnit = require('qunit');
 
 QUnit.module('jQuery fallback');
 
-QUnit.test('main.js runs with local jQuery when CDN fails', assert => {
+QUnit.test('main.js runs with local jQuery when CDN fails', async assert => {
   const dom = new JSDOM('<!doctype html><html><body></body></html>', {
     runScripts: 'outside-only',
     url: 'http://localhost'
@@ -24,7 +22,9 @@ QUnit.test('main.js runs with local jQuery when CDN fails', assert => {
   window.eval(fallback);
 
   if (!window.jQuery) {
-    jQueryFactory(window);
+    const { default: jQuery } = await import('jquery');
+    window.$ = window.jQuery = jQuery;
+    global.jQuery = jQuery;
   }
 
   // Prevent jsdom "Not implemented" alert errors
@@ -35,9 +35,13 @@ QUnit.test('main.js runs with local jQuery when CDN fails', assert => {
     fail: cb => { setTimeout(cb, 0); }
   });
 
-  const main = fs.readFileSync('js/main.js', 'utf8');
-  window.eval(main);
+  await import('../js/main.js');
 
   assert.ok(window.jQuery, 'jQuery loaded');
   assert.strictEqual(typeof window.calculateTotals, 'function', 'main.js executed');
+
+  delete global.jQuery;
+  delete global.alert;
+  delete global.window;
+  delete global.document;
 });


### PR DESCRIPTION
## Summary
- use async import for `jqueryFallback.test.cjs`
- clean up globals after the test

## Testing
- `npm test` *(fails: jQuery is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68468ab7b0d88321a6cdf43abda56959