### PR TITLE
Remove global jQuery from lint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,8 +13,7 @@ export default [
     languageOptions: {
       ecmaVersion: 2020,
       globals: {
-        ...globals.browser,
-        ...globals.jquery
+        ...globals.browser
       }
     },
     rules: {

--- a/js/main.js
+++ b/js/main.js
@@ -34,7 +34,7 @@
     }
     let profiles = storageGet(profilesKey, defaultProfiles);
 
-    jQuery(document).ready(function($) {
+    $(document).ready(function() {
 
         loadPlaythrough();
         loadChecklists();
@@ -501,4 +501,4 @@
         window.getFirstProfile = getFirstProfile;
     }
 
-})( jQuery );
+})( window.jQuery );

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "build": "node scripts/build.js",
     "start": "npx serve",
     "test": "qunit tests",
-    "lint": "eslint js/*.js tests/*.cjs"
+    "lint": "eslint --no-warn-ignored js/*.js tests/*.cjs"
   }
 }


### PR DESCRIPTION
## Summary
- drop jQuery browser global from ESLint config
- fix main.js to reference window.jQuery and use `$` directly
- suppress warnings for ignored files in npm script

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68468ac6152c8321862cbc07bc0aa695