### PR TITLE
Add tooling checks and integration test

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+node_modules
+js/bootstrap.min.js
+js/jquery-3.7.1.min.js
+service-worker.js

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "none",
+  "printWidth": 100
+}

--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ npm run test:ui
 ```
 
 The tests execute under Node.js using jsdom to simulate a browser environment.
-Run `npm run lint` to check code style across the `js/` directory and the `tests/` sources. A
-separate UI test exercises localStorage integration and can be executed with `npm run test:ui`.
+Run `npm run lint` to check code style across the `js/` directory and the `tests/` sources.
+Format files with `npm run format` and run `npm run typecheck` for a lightweight TypeScript
+check. A separate UI test exercises localStorage integration and can be executed with
+`npm run test:ui`.
 
 ## Filtering Items
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,10 @@
         "eslint": "^9.28.0",
         "jquery": "^3.7.1",
         "jsdom": "^26.1.0",
+        "prettier": "^3.5.3",
         "qunit": "^2.20.0",
-        "serve": "^14.2.4"
+        "serve": "^14.2.4",
+        "typescript": "^5.8.3"
       },
       "engines": {
         "node": ">=20"
@@ -2116,6 +2118,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -2543,6 +2561,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/update-check": {

--- a/package.json
+++ b/package.json
@@ -13,13 +13,17 @@
     "jsdom": "^26.1.0",
     "qunit": "^2.20.0",
     "serve": "^14.2.4",
-    "@testing-library/dom": "^10.4.0"
+    "@testing-library/dom": "^10.4.0",
+    "prettier": "^3.5.3",
+    "typescript": "^5.8.3"
   },
   "scripts": {
     "build": "node scripts/build.js",
     "start": "npx serve",
     "test": "qunit tests",
-    "lint": "eslint js/*.js tests/*.cjs",
+    "lint": "eslint js/*.js tests/*.cjs && prettier --check .",
+    "format": "prettier --write .",
+    "typecheck": "tsc --noEmit",
     "test:ui": "qunit tests/uiLocalStorageSync.test.cjs"
   }
 }

--- a/tests/indexIntegration.test.cjs
+++ b/tests/indexIntegration.test.cjs
@@ -1,0 +1,73 @@
+const { JSDOM } = require('jsdom');
+const QUnit = require('qunit');
+const fs = require('fs');
+const path = require('path');
+
+function teardownDom(dom) {
+  delete global.$;
+  delete global.jQuery;
+  if (global.window) {
+    delete global.window.$;
+  }
+  delete global.window;
+  delete global.document;
+  delete global.alert;
+  if (dom) {
+    dom.window.close();
+  }
+}
+
+async function setupDom() {
+  const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
+  const dom = new JSDOM(html, { url: 'http://localhost' });
+  const { window } = dom;
+  global.window = window;
+  global.document = window.document;
+  window.profilesKey = 'profiles';
+  global.alert = () => {};
+  alert = global.alert;
+
+  delete require.cache[require.resolve('jquery')];
+  const $ = require('jquery')(window);
+  global.$ = global.jQuery = window.$ = $;
+
+  $.getJSON = (url, cb) => {
+    if (url.includes('playthrough')) {
+      setTimeout(
+        () =>
+          cb([
+            { id: 'section1', title: 'Section 1', items: [{ id: 'foo_1_1', content: 'Item' }] }
+          ]),
+        0
+      );
+    } else if (url.includes('checklists')) {
+      setTimeout(() => cb([]), 0);
+    } else {
+      setTimeout(() => cb([]), 0);
+    }
+    return { fail: () => {} };
+  };
+
+  await import('../js/main.js');
+  document.dispatchEvent(new window.Event('DOMContentLoaded'));
+  return dom;
+}
+
+QUnit.module('index.html integration', hooks => {
+  let dom;
+  hooks.beforeEach(async () => {
+    dom = await setupDom();
+    return new Promise(r => setTimeout(r, 50));
+  });
+
+  hooks.afterEach(() => {
+    teardownDom(dom);
+  });
+
+  QUnit.test('renders playthrough via index.html template', assert => {
+    const li = document.querySelector('li[data-id="foo_1_1"]');
+    assert.ok(li, 'list item rendered');
+    const nav = document.querySelector('#playthrough_nav li a');
+    assert.ok(nav && nav.textContent.includes('Section 1'), 'nav rendered');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "esnext",
+    "moduleResolution": "node16",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "js/**/*.js",
+    "scripts/**/*.js",
+    "tests/**/*.cjs"
+  ],
+  "exclude": [
+    "node_modules",
+    "js/bootstrap.min.js",
+    "js/jquery-3.7.1.min.js"
+  ]
+}


### PR DESCRIPTION
## Summary
- enforce consistent style with Prettier
- add a basic tsconfig for type checking
- document new development commands
- new integration test loading `index.html`

## Testing
- `npm test` *(fails: globalThis.alert is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68470818dd248321b0f89779d597f74c