### PR TITLE
Fix alert stubs in tests

### DIFF
--- a/tests/indexIntegration.test.cjs
+++ b/tests/indexIntegration.test.cjs
@@ -12,6 +12,7 @@ function teardownDom(dom) {
   delete global.window;
   delete global.document;
   delete global.alert;
+  delete globalThis.alert;
   if (dom) {
     dom.window.close();
   }
@@ -24,7 +25,7 @@ async function setupDom() {
   global.window = window;
   global.document = window.document;
   window.profilesKey = 'profiles';
-  global.alert = () => {};
+  global.alert = globalThis.alert = () => {};
   alert = global.alert;
 
   delete require.cache[require.resolve('jquery')];

--- a/tests/loadChecklistsFail.test.cjs
+++ b/tests/loadChecklistsFail.test.cjs
@@ -22,7 +22,7 @@ QUnit.module('loadChecklists failure', hooks => {
     });
 
     alertCalled = false;
-    global.alert = () => { alertCalled = true; };
+    global.alert = globalThis.alert = () => { alertCalled = true; };
     alert = global.alert;
 
     await import('../js/main.js');
@@ -35,6 +35,7 @@ QUnit.module('loadChecklists failure', hooks => {
     delete global.jQuery;
     delete window.$;
     delete global.alert;
+    delete globalThis.alert;
     delete global.window;
     delete global.document;
   });

--- a/tests/loadPlaythroughFail.test.cjs
+++ b/tests/loadPlaythroughFail.test.cjs
@@ -22,7 +22,7 @@ QUnit.module('loadPlaythrough failure', hooks => {
     });
 
     alertCalled = false;
-    global.alert = () => { alertCalled = true; };
+    global.alert = globalThis.alert = () => { alertCalled = true; };
     alert = global.alert;
 
     await import('../js/main.js');
@@ -35,6 +35,7 @@ QUnit.module('loadPlaythrough failure', hooks => {
     delete global.jQuery;
     delete window.$;
     delete global.alert;
+    delete globalThis.alert;
     delete global.window;
     delete global.document;
   });

--- a/tests/profileAddDuplicate.test.cjs
+++ b/tests/profileAddDuplicate.test.cjs
@@ -32,7 +32,7 @@ QUnit.module('profile add duplicate', hooks => {
     window.localStorage.setItem('profiles', JSON.stringify(store));
 
     alertCalled = false;
-    global.alert = () => { alertCalled = true; };
+    global.alert = globalThis.alert = () => { alertCalled = true; };
     alert = global.alert; // expose
 
     await import('../js/main.js');
@@ -45,6 +45,7 @@ QUnit.module('profile add duplicate', hooks => {
     delete global.jQuery;
     delete window.$;
     delete global.alert;
+    delete globalThis.alert;
     delete global.window;
     delete global.document;
   });

--- a/tests/profileRename.test.cjs
+++ b/tests/profileRename.test.cjs
@@ -32,7 +32,7 @@ QUnit.module('profile rename', hooks => {
     window.localStorage.setItem('profiles', JSON.stringify(store));
 
     alertCalled = false;
-    global.alert = () => { alertCalled = true; };
+    global.alert = globalThis.alert = () => { alertCalled = true; };
     alert = global.alert; // expose as global variable for strict mode
 
     await import('../js/main.js');
@@ -45,6 +45,7 @@ QUnit.module('profile rename', hooks => {
     delete global.jQuery;
     delete window.$;
     delete global.alert;
+    delete globalThis.alert;
     delete global.window;
     delete global.document;
   });


### PR DESCRIPTION
## Summary
- assign `globalThis.alert` alongside `global.alert` in unit tests
- clean up `globalThis.alert` in teardown steps

## Testing
- `npm test` *(fails: Unable to fire a "click" event - please provide a DOM element)*

------
https://chatgpt.com/codex/tasks/task_e_6847106dab988321bf69f71bae2a2a99